### PR TITLE
Get pip install -r requirements_dev.txt working

### DIFF
--- a/requirements_conda.txt
+++ b/requirements_conda.txt
@@ -89,9 +89,6 @@ azure-storage-common==1.3.0
 azure-storage-file==1.3.1
 azure-storage-nspkg==3.0.0
 azure-storage-queue==1.3.0
-base58==0.2.5
-# BigchainDB==1.3.0
-# bigchaindb-driver==0.5.1
 bumpversion==0.5.3
 certifi==2018.8.13
 cffi==1.11.5
@@ -101,8 +98,6 @@ codacy-coverage==1.3.11
 coincurve==8.0.2
 coloredlogs==10.0
 coverage==4.5.1
-# cryptoconditions==0.6.0.dev1
-cryptography==2.3.1
 cytoolz==0.9.0.1
 eciespy==0.1.2
 eth-abi==1.1.1
@@ -150,7 +145,6 @@ pkginfo==1.4.2
 pluggy==0.6.0
 py==1.5.4
 py-solc==3.1.0
-pyasn1==0.2.3
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodome==3.6.6
@@ -164,7 +158,6 @@ pysha3==1.0.2
 pytest==3.4.2
 pytest-runner==2.11.1
 python-dateutil==2.7.3
-python-rapidjson==0.6.3
 python-rapidjson-schema==0.1.1
 pytz==2018.5
 PyYAML==3.13

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -6,9 +6,6 @@ asn1crypto==0.24.0
 async-timeout==3.0.0
 attrdict==2.0.0
 attrs==18.1.0
-base58==0.2.5
-BigchainDB==1.3.0
-bigchaindb-driver==0.5.1
 bumpversion==0.5.3
 certifi==2018.8.13
 cffi==1.11.5
@@ -18,8 +15,6 @@ codacy-coverage==1.3.11
 coincurve==8.0.2
 coloredlogs==10.0
 coverage==4.5.1
-cryptoconditions==0.6.0.dev1
-cryptography==2.3.1
 cytoolz==0.9.0.1
 eciespy==0.1.2
 eth-abi==1.1.1
@@ -56,7 +51,7 @@ multidict==4.3.1
 multipipes==0.1.0
 oauthlib==2.1.0
 squid-py==0.2.1
-oceandb-bigchaindb-driver==0.1.3
+# oceandb-bigchaindb-driver==0.1.3
 oceandb-driver-interface==0.1.11
 oceandb-elasticsearch-driver==0.0.2
 oceandb-mongodb-driver==0.1.3
@@ -66,7 +61,6 @@ pkginfo==1.4.2
 pluggy==0.6.0
 py==1.5.4
 py-solc==3.1.0
-pyasn1==0.2.3
 pycodestyle==2.3.1
 pycparser==2.18
 pycryptodome==3.6.6
@@ -80,7 +74,6 @@ pysha3==1.0.2
 pytest==3.4.2
 pytest-runner==2.11.1
 python-dateutil==2.7.3
-python-rapidjson==0.6.3
 python-rapidjson-schema==0.1.1
 pytz==2018.5
 PyYAML==3.13


### PR DESCRIPTION
This pull request removes several dependencies from requirements_dev.txt (and _conda.txt):

- Direct requirements for `base58`, `BigchainDB`, `bigchaindb-driver`, `cryptoconditions`, `cryptography`, `pyasn1` and `python-rapidjson` aren't needed, because those should come indirectly through the requirements of `oceandb-bigchaindb-driver`
- The requirement for `oceandb-bigchaindb-driver` was commented-out for now, because it was causing problems: if you [look at the setup.py file for that package](https://github.com/oceanprotocol/oceandb-bigchaindb-driver/blob/3900a665c7a43307181be118fa53e46a9b45784c/setup.py#L14), you'll see that it lists `bigchaindb-driver` and `BigchainDB` as requirements, but since no version is specified for `BigchainDB`, it assumes the latest non-beta, non-alpha version, which is 1.3.0!

Therefore the oceandb-bigchaindb-driver package requirements will have to be fixed (in a separate PR), but it's not really needed at the moment (since we're usually using MongoDB, not BigchainDB, as the metadata store), so I just commented-out that dependency for now.

Note: I only tested `pip install -r requirements_dev.txt` in a fresh Python 3.6.6 virtual environment. I didn't test the coda requirements file. I plan to address the conda case in follow-up PRs.