### PR TITLE
Removed all mentions of keepers, Ganache and Azure

### DIFF
--- a/aquarius/__init__.py
+++ b/aquarius/__init__.py
@@ -1,5 +1,4 @@
-"""Provide an off-chain database store for data assets metadata and registration and perform part of access control
-in collaboration with the keeper-contracts."""
+"""Provide an off-chain database store for data asset metadata and registration."""
 
 __author__ = """OceanProtocol"""
 __version__ = '0.1.1'

--- a/config.ini.template
+++ b/config.ini.template
@@ -39,20 +39,5 @@ db.collection=${DB_COLLECTION}
 ;db.app_id=54ed26dd
 ;db.app_key=d068996d8d5b1a66cfc61dc3a83fa7ee
 
-[keeper-contracts]
-keeper.url = ${KEEPER_URL}
-keeper.network = ${KEEPER_NETWORK}
-
-;contracts.folder=venv/contracts
-market.address = ${MARKET_ADDRESS}
-auth.address = ${AUTH_ADDRESS}
-token.address = ${TOKEN_ADDRESS}
-aquarius.address = ${AQUARIUS_ADDRESS}
-
-[resources]
-azure.account.name = ${AZURE_ACCOUNT_NAME}
-azure.account.key = ${AZURE_ACCOUNT_KEY}
-azure.container = ${AZURE_CONTAINER}
-
-; These consitute part of the aquarius url which is used in setting the `api_url` in the `OceanContractsWrapper`
+; These constitute part of the aquarius url which is used in setting the `api_url` in the `OceanContractsWrapper`
 aquarius.url = ${AQUARIUS_URL}

--- a/docs/for_aquarius_devs/README.md
+++ b/docs/for_aquarius_devs/README.md
@@ -24,7 +24,6 @@ docker-compose up
 
 You can see what that runs by reading [docker/docker-compose.yml](docker/docker-compose.yml).
 Note that it runs MongoDB but the Aquarius can also work with BigchainDB or Elasticsearch.
-It also runs [Ganache](https://github.com/trufflesuite/ganache) with all [Ocean Protocol Keeper Contracts](https://github.com/oceanprotocol/keeper-contracts) and [Ganache CLI](https://github.com/trufflesuite/ganache-cli).
 
 Then install Aquarius's OS-level requirements:
 


### PR DESCRIPTION
because Aquarius no longer connects to any Ethereum client (such as Ganache) and so doesn't need to know any contract addresses. Also, Aquarius no longer needs an Azure account account name, account key or container name.