### PR TITLE
Point would-be Aquarius operators to the docs site

### DIFF
--- a/docs/for_operators/README.md
+++ b/docs/for_operators/README.md
@@ -2,4 +2,4 @@
 
 This documentation is for someone who just wants to _run_ Aquarius, such as someone operating a data marketplace in the Ocean Network.
 
-Coming Soon!
+_For now_, if you're developing a marketplace, you'll want to run Aquarius and several other components, and the easiest way to do all that is to use our Docker Compose setup. For details, see [the docs page about setting up a marketplace](https://docs.oceanprotocol.com/setup/marketplace/).


### PR DESCRIPTION
For now, anyone setting up a marketplace should probably just use the Docker Compose setup that Pleuston devs use, to run Aquarius and several other components. That's all outlined on the docs page about setting up a marketplace, so I linked there.