### PR TITLE
Consolidate bumpversion config in .bumpversion.cfg

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,7 +1,12 @@
 [bumpversion]
 current_version = 0.1.4
-
-[bumpversion:file:setup.cfg]
+commit = True
+tag = True
 
 [bumpversion:file:setup.py]
+search = version='{current_version}'
+replace = version='{new_version}'
 
+[bumpversion:file:aquarius/__init__.py]
+search = __version__ = '{current_version}'
+replace = __version__ = '{new_version}'

--- a/aquarius/__init__.py
+++ b/aquarius/__init__.py
@@ -1,4 +1,4 @@
 """Provide an off-chain database store for data asset metadata and registration."""
 
 __author__ = """OceanProtocol"""
-__version__ = '0.1.1'
+__version__ = '0.1.4'

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,16 +1,3 @@
-[bumpversion]
-current_version = 0.1.4
-commit = True
-tag = True
-
-[bumpversion:file:setup.py]
-search = version='{current_version}'
-replace = version='{new_version}'
-
-[bumpversion:file:aquarius/__init__.py]
-search = __version__ = '{current_version}'
-replace = __version__ = '{new_version}'
-
 [bdist_wheel]
 universal = 1
 
@@ -18,11 +5,9 @@ universal = 1
 exclude = docs
 ignore = E501, E402
 
-
 [aliases]
 # Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-


### PR DESCRIPTION
This PR is the Aquarius analogue of https://github.com/oceanprotocol/brizo/pull/50 ... see the comments I made there to understand it.

Note that in Aquarius, the `__init__.py` file isn't empty, but it also wasn't getting updated because a `.bumpversion.cfg` file existed, so `setup.cfg` was being ignored by the bumpversion script.