### PR TITLE
Cleanup Flake8

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,9 +52,6 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
-lint: ## check style with flake8
-	flake8 aquarius tests
-
 test: ## run tests quickly with the default Python
 	py.test
 

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,9 @@ clean-test: ## remove test and coverage artifacts
 	rm -fr htmlcov/
 	rm -fr .pytest_cache
 
+lint: ## check style with PyLint
+	pylint --errors-only aquarius tests
+
 test: ## run tests quickly with the default Python
 	py.test
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,15 +14,9 @@ replace = __version__ = '{new_version}'
 [bdist_wheel]
 universal = 1
 
-[flake8]
-exclude = docs
-ignore = E501, E402
-
-
 [aliases]
 # Define setup.py command aliases here
 test = pytest
 
 [tool:pytest]
 collect_ignore = ['setup.py']
-

--- a/setup.py
+++ b/setup.py
@@ -39,9 +39,8 @@ dev_requirements = [
 test_requirements = [
     'codacy-coverage==1.3.11',
     'coverage==4.5.1',
-    'flake8==3.5.0',
     'mccabe==0.6.1',
-    'pyflakes==1.6.0',
+    'pylint==2.2.2',
     'pytest==3.4.2',
     'tox==3.2.1',
 ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,15 +1,10 @@
 [tox]
-envlist = py36, py37, flake8
+envlist = py36, py37
 
 [travis]
 python =
     3.6: py36
     3.7: py37
-
-[testenv:flake8]
-basepython = python
-deps = flake8
-commands = flake8 aquarius
 
 [testenv]
 passenv = CODACY_PROJECT_TOKEN


### PR DESCRIPTION
We use Codacy (which uses PyLint) to check Python code style, not Flake8 or pyflakes, so I removed all the Flake8 and pyflakes stuff. I also changed `make lint` to use PyLint instead of Flake8.