### PR TITLE
Dockerfile shouldn't install Aquarius in editable mode

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ COPY . /aquarius
 WORKDIR /aquarius
 
 # Only install install_requirements, not dev_ or test_requirements
-RUN pip install -e .
+RUN pip install .
 
 # config.ini configuration file variables
 ENV DB_ENABLED='true'


### PR DESCRIPTION
In the `Dockerfile`, I changed `pip install -e .` (where `.` means the current directory) to get rid of the `-e` because that option is only if you want to keep pip re-installing from the local code (in `.`) every time the local code changes.

More info: https://pip.pypa.io/en/stable/reference/pip_install/#editable-installs

