### PR TITLE
Remove all mentions of BDB app_id and app_key

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,6 @@ ENV DB_INDEX='aquarius'
 #BDB
 ENV DB_SECRET=''
 ENV DB_SCHEME='http'
-ENV DB_APP_ID=''
-ENV DB_APP_KEY=''
 ENV DB_NAMESPACE='namespace'
 ENV AQUARIUS_URL='http://0.0.0.0:5000'
 # docker-entrypoint.sh configuration file variables

--- a/config.ini
+++ b/config.ini
@@ -42,8 +42,6 @@ db.client_cert_path=
 ;db.scheme=https
 ;db.hostname=test.bigchaindb.com
 ;db.port=
-;db.app_id=54ed26dd
-;db.app_key=d068996d8d5b1a66cfc61dc3a83fa7ee
 
 [resources]
 aquarius.url = http://localhost:5000

--- a/config.ini.template
+++ b/config.ini.template
@@ -14,8 +14,6 @@ db.index = ${DB_INDEX}
 ############################################### BDB ###############################################
 secret = ${DB_SECRET}
 db.scheme = ${DB_SCHEME}
-db.app_id = ${DB_APP_ID}
-db.app_key = ${DB_APP_KEY}
 db.namespace = ${DB_NAMESPACE}
 
 [resources]


### PR DESCRIPTION
The BigchainDB Testnet used to require an app_id and app_key in the HTTP request header, but it doesn't anymore, so we can remove all mentions of those.

I will do a similar pull request in https://github.com/oceanprotocol/oceandb-bigchaindb-driver
