### PR TITLE
Fixed a typo in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requirements = [
     # 'oceandb-bigchaindb-driver==0.1.4',
     'PyYAML==4.2b4',
     'pytz==2018.5',
-    'plecos===0.5.2'
+    'plecos==0.5.2'
 ]
 
 setup_requirements = ['pytest-runner==2.11.1', ]


### PR DESCRIPTION
I was getting an error when trying to install Aquarius from source and it turned out to be because of this typo.