### PR TITLE
Update swagger & PyYAML packages to latest

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,14 +17,14 @@ install_requirements = [
     'coloredlogs==10.0',
     'Flask==1.0.2',
     'Flask-Cors==3.0.6',
-    'flask-swagger==0.2.13',
-    'flask-swagger-ui==3.6.0',
+    'flask-swagger==0.2.14',
+    'flask-swagger-ui==3.20.9',
     'gunicorn==19.9.0',
     'oceandb-driver-interface==0.2.0',
     'oceandb-mongodb-driver==0.1.9',
     'oceandb-elasticsearch-driver==0.0.5',
     # 'oceandb-bigchaindb-driver==0.1.4',
-    'PyYAML==4.2b4',
+    'PyYAML==5.1',
     'pytz==2018.5',
     'plecos==0.7.0'
 ]


### PR DESCRIPTION
The Swagger JSON spec (API spec) generated using the `flask-swagger` and `flask-swagger-ui` packages contains 39 errors, according to SwaggerHub. In an attempt to fix some of those errors, I updated those two packages (and one of their dependencies, `PyYAML`) to the latest versions to see if that would help.

It didn't change the number of errors (according to SwaggerHub), but all the tests pass (when I run `tox`, for both Python 3.6 and Python 3.7), and the Swagger UI API docs look a bit different now, so I figured it still might be worthwhile to update those three Python packages. Below is a screenshot of the locally-generated Swagger UI API docs after the update:

![Screenshot from 2019-04-09 14-38-03](https://user-images.githubusercontent.com/1210951/55801931-7477fd80-5ad7-11e9-8bc3-3bbb9261123d.png)

I wouldn't bother with doing a new release of Aquarius because of this PR.

The 39 errors might be fixable by editing the YAML in the Aquarius docstrings, but maybe not. They might just be some quirk of how `flask-swagger` and `flask-swagger-ui` work. In any case, Swagger Hub is still able to generate decent Aquarius API docs, despite the "39 errors", so I'm not sure those errors matter.