### PR TITLE
filter multiple pools

### DIFF
--- a/aquarius/events/metadata_updater.py
+++ b/aquarius/events/metadata_updater.py
@@ -268,7 +268,7 @@ class MetadataUpdater:
             return None
 
         pools = [get_event_data(event_abi, log).address for log in logs]
-        return pools
+        return list(set(pools))
 
     def _get_liquidity_and_price(self, pools, dt_address):
         assert pools, f'pools should not be empty, got {pools}'


### PR DESCRIPTION
Sometime, we will get multiple events => same pool.  Let's filter that, in order to avoid structure like this:

"price": {
    "datatoken": 489.7318486533372,
    "ocean": 560282.3065683485,
    "value": 503.6179181382843,
    "type": "pool",
    "address": "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
    "pools": [
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xAAB9EaBa1AA2653c1Dda9846334700b9F5e14E44",
      "0xa81798FEc662C1A131029B28546Cc80ECd11CB61"
    ],
    "isConsumable": "true"