### PR TITLE
Add price.adddress again for pools

### DIFF
--- a/aquarius/events/events_monitor.py
+++ b/aquarius/events/events_monitor.py
@@ -404,6 +404,7 @@ class EventsMonitor(BlockProcessingClass):
             "ocean": 0.0,
             "value": 0.0,
             "type": "",
+            "exchange_id": "",
             "address": "",
             "pools": [],
             "isConsumable": "",

--- a/aquarius/events/metadata_updater.py
+++ b/aquarius/events/metadata_updater.py
@@ -461,14 +461,14 @@ class MetadataUpdater(BlockProcessingClass):
                 "Found price not None, setting "
                 f"address={self.ex_contract.address} and type as empty string."
             )
-            price_dict.update({"exchange_id": exchange_id, "type": "exchange"})
-            price_dict.update({"address": "", "type": ""})
+            price_dict.update(
+                {"exchange_id": exchange_id, "type": "exchange", "address": ""}
+            )
         else:
             logger.info(
                 "Found price=None, setting address and type as empty string."
             )  # noqa
-            price_dict.update({"address": "", "type": ""})
-            price_dict.update({"exchange_id": "", "type": ""})
+            price_dict.update({"address": "", "type": "", "exchange_id": ""})
         return price_dict
 
     def _get_price_updates_from_liquidity(self, pools, _dt_address):

--- a/aquarius/events/metadata_updater.py
+++ b/aquarius/events/metadata_updater.py
@@ -385,17 +385,17 @@ class MetadataUpdater(BlockProcessingClass):
 
             ex_data = fre.getExchange(exchange_id)
             if not ex_data or not ex_data.exchangeOwner:
-                return None, None
+                return None, None, None
 
             price = from_base_18(ex_data.fixedRate)
             supply = from_base_18(ex_data.supply)
-            return price, supply
+            return price, supply, exchange_id
         except Exception as e:
             logger.error(
                 f"Reading exchange price failed for datatoken {dt_address}, "
                 f"owner {owner}, exchangeId {exchange_id}: {e}"
             )
-            return None, None
+            return None, None, None
 
     def get_all_pools(self):
         bfactory = BFactory(self._addresses.get(BFactory.CONTRACT_NAME))
@@ -429,7 +429,7 @@ class MetadataUpdater(BlockProcessingClass):
                 _dt_address, exchange_id=exchange_id
             )
         else:
-            price, dt_supply = self._get_fixedrateexchange_price(
+            price, dt_supply, exchange_id = self._get_fixedrateexchange_price(
                 _dt_address, owner
             )  # noqa
 
@@ -461,13 +461,14 @@ class MetadataUpdater(BlockProcessingClass):
                 "Found price not None, setting "
                 f"address={self.ex_contract.address} and type as empty string."
             )
-            price_dict.update({"address": self.ex_contract.address, "type": "exchange"})
+            price_dict.update({"exchange_id": exchange_id, "type": "exchange"})
+            price_dict.update({"address": "", "type": ""})
         else:
             logger.info(
                 "Found price=None, setting address and type as empty string."
             )  # noqa
             price_dict.update({"address": "", "type": ""})
-
+            price_dict.update({"exchange_id": "", "type": ""})
         return price_dict
 
     def _get_price_updates_from_liquidity(self, pools, _dt_address):


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

Aquarius issue #388 requested removing price.address and replacing it with price.exchange_id. However price.address is needed for pools. It was added back in for the appropriate cases.

## Is this PR related with an open issue?

Related to Issue #

## Types of changes

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 


#### Funny gif

![Put a link of a funny gif inside the parenthesis-->]()