### PR TITLE
Tones down asset not found errors.

### DIFF
--- a/aquarius/app/assets.py
+++ b/aquarius/app/assets.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 import ecies
+import elasticsearch
 import json
 import logging
 import os
@@ -94,6 +95,8 @@ def get_ddo(did):
         return Response(
             sanitize_record(asset_record), 200, content_type="application/json"
         )
+    except elasticsearch.exceptions.NotFoundError:
+        return f"{did} asset DID is not in OceanDB", 404
     except Exception as e:
         logger.error(f"get_ddo: {str(e)}")
         return f"{did} asset DID is not in OceanDB", 404

--- a/aquarius/app/dao.py
+++ b/aquarius/app/dao.py
@@ -23,10 +23,8 @@ class Dao(object):
     def get(self, asset_id):
         try:
             asset = self.oceandb.read(asset_id)
-        except elasticsearch.exceptions.NotFoundError as e:
-            logging.error(
-                f"Dao.get -- asset with id {asset_id} was not found, original error was:{str(e)}"
-            )
+        except elasticsearch.exceptions.NotFoundError:
+            logging.info(f"Dao.get: asset with id {asset_id} was not found in OceanDB.")
             raise
 
         except Exception as e:


### PR DESCRIPTION
Treat ElasticSearch NotFoundExceptions in get by did endpoint as misses, not errors. Remove overzealous logging and make these an informative log.

Closes #414.