### PR TITLE
Fix log statements related to price.exchange_id

### DIFF
--- a/aquarius/events/metadata_updater.py
+++ b/aquarius/events/metadata_updater.py
@@ -434,10 +434,10 @@ class MetadataUpdater(BlockProcessingClass):
             )  # noqa
 
         logger.info(
-            f"Updating price for asset with address {_dt_address}, with"
+            f"Updating price for asset with address {_dt_address}, with "
             f"owner={owner}"
             if owner
-            else f"echange_id={exchange_id}, " f"from FIXED RATE EXCHANGE."
+            else f"exchange_id={exchange_id}, " f"from FIXED RATE EXCHANGE."
         )
 
         is_consumable = str(bool(dt_supply is not None and dt_supply > 1)).lower()
@@ -459,14 +459,16 @@ class MetadataUpdater(BlockProcessingClass):
         if price is not None:
             logger.info(
                 "Found price not None, setting "
-                f"address={self.ex_contract.address} and type as empty string."
+                f"address={self.ex_contract.address}, type=exchange, and "
+                "exchange_id as empty string."
             )
             price_dict.update(
                 {"exchange_id": exchange_id, "type": "exchange", "address": ""}
             )
         else:
             logger.info(
-                "Found price=None, setting address and type as empty string."
+                "Found price=None, setting address, type, and exchange_id as "
+                "empty string."
             )  # noqa
             price_dict.update({"address": "", "type": "", "exchange_id": ""})
         return price_dict


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

This PR simply fixes a couple of log statements that were not updated when the `exchange_id` logic changed in #424. The erroneous logs were discovered while investigating #410. 

## Is this PR related with an open issue?

Closes #435 
Cleanup for #424

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://media1.tenor.com/images/da398fd391b58b8d25a04f737aa7521f/tenor.gif)