### PR TITLE
add encrypt_as_hex

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -219,6 +219,19 @@ def test_encrypt_ddo(client, base_ddo_url, events_object):
     key = eth_keys.KeyAPI.PrivateKey(ecies_account.privateKey)
     decrypted_ddo = ecies.decrypt(key.to_hex(), Web3.toBytes(encrypted_ddo))
     assert decrypted_ddo == compressed_ddo
+    # test encrypt as hex
+    _response_hex = client.post(
+        base_ddo_url + "/encryptashex",
+        data=compressed_ddo,
+        content_type="application/text",
+    )
+    assert _response_hex.status_code == 200
+    encrypted_ddo_hex = _response_hex.data
+    decrypted_ddo_from_hex = ecies.decrypt(
+        key.to_hex(), Web3.toBytes(encrypted_ddo_hex)
+    )
+    assert decrypted_ddo_from_hex == compressed_ddo
+
     send_create_update_tx(
         "create", ddo["id"], bytes([3]), Web3.toBytes(encrypted_ddo), test_account1
     )


### PR DESCRIPTION
## Description
Adds an additional endpoint: /ddo/encryptashex  which will return the encrypted ddo as hex, instead of bytes

## Is this PR related with an open issue?
On the frontend world, it's hard to use buffers & bytes because of deps & conflicts between nodejs & browser
Using this endpoint, the response is plain text, no need for encodings
## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
