### PR TITLE
Add python3-dev and wheel to install instructions (#519)

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ Install Aquarius's OS-level requirements:
 
 ```bash
 sudo apt update
-sudo apt install python3
+sudo apt install python3-dev
 ```
 
 It is recommended that you create and activate a virtual environment in order to install the dependencies.
@@ -174,6 +174,7 @@ source venv/bin/activate
 At this point, with the Elasticsearch database already running, now you can start the Aquarius server:
 
 ```bash
+pip install wheel
 pip install -r requirements.txt
 export FLASK_APP=aquarius/run.py
 export CONFIG_FILE=config.ini


### PR DESCRIPTION
Fixes #519 

Changes:

* Add python3-dev and wheel to the install instructions

Test:

<details>
<summary>Console log of successful install</summary>
<p>

```console
david@david-Inspiron-5502:~/projects/aquarius$ apt list --installed python3-dev
Listing... Done
david@david-Inspiron-5502:~/projects/aquarius$ sudo apt install python3-dev
[sudo] password for david: 
Reading package lists... Done
Building dependency tree       
Reading state information... Done
The following additional packages will be installed:
  libexpat1-dev libpython3-dev libpython3.8-dev python3.8-dev
The following NEW packages will be installed:
  libexpat1-dev libpython3-dev libpython3.8-dev python3-dev python3.8-dev
0 upgraded, 5 newly installed, 0 to remove and 116 not upgraded.
Need to get 4,577 kB of archives.
After this operation, 21.5 MB of additional disk space will be used.
Do you want to continue? [Y/n] y
Get:1 http://us.archive.ubuntu.com/ubuntu focal/main amd64 libexpat1-dev amd64 2.2.9-1build1 [116 kB]
Get:2 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 libpython3.8-dev amd64 3.8.10-0ubuntu1~20.04 [3,943 kB]
Get:3 http://us.archive.ubuntu.com/ubuntu focal/main amd64 libpython3-dev amd64 3.8.2-0ubuntu2 [7,236 B]
Get:4 http://us.archive.ubuntu.com/ubuntu focal-updates/main amd64 python3.8-dev amd64 3.8.10-0ubuntu1~20.04 [510 kB]
Get:5 http://us.archive.ubuntu.com/ubuntu focal/main amd64 python3-dev amd64 3.8.2-0ubuntu2 [1,212 B]
Fetched 4,577 kB in 0s (10.8 MB/s)      
Selecting previously unselected package libexpat1-dev:amd64.
(Reading database ... 355632 files and directories currently installed.)
Preparing to unpack .../libexpat1-dev_2.2.9-1build1_amd64.deb ...
Unpacking libexpat1-dev:amd64 (2.2.9-1build1) ...
Selecting previously unselected package libpython3.8-dev:amd64.
Preparing to unpack .../libpython3.8-dev_3.8.10-0ubuntu1~20.04_amd64.deb ...
Unpacking libpython3.8-dev:amd64 (3.8.10-0ubuntu1~20.04) ...
Selecting previously unselected package libpython3-dev:amd64.
Preparing to unpack .../libpython3-dev_3.8.2-0ubuntu2_amd64.deb ...
Unpacking libpython3-dev:amd64 (3.8.2-0ubuntu2) ...
Selecting previously unselected package python3.8-dev.
Preparing to unpack .../python3.8-dev_3.8.10-0ubuntu1~20.04_amd64.deb ...
Unpacking python3.8-dev (3.8.10-0ubuntu1~20.04) ...
Selecting previously unselected package python3-dev.
Preparing to unpack .../python3-dev_3.8.2-0ubuntu2_amd64.deb ...
Unpacking python3-dev (3.8.2-0ubuntu2) ...
Setting up libexpat1-dev:amd64 (2.2.9-1build1) ...
Setting up libpython3.8-dev:amd64 (3.8.10-0ubuntu1~20.04) ...
Setting up python3.8-dev (3.8.10-0ubuntu1~20.04) ...
Setting up libpython3-dev:amd64 (3.8.2-0ubuntu2) ...
Setting up python3-dev (3.8.2-0ubuntu2) ...
Processing triggers for man-db (2.9.1-1) ...
david@david-Inspiron-5502:~/projects/aquarius$ python3 -m venv venv
david@david-Inspiron-5502:~/projects/aquarius$ source venv/bin/activate
(venv) david@david-Inspiron-5502:~/projects/aquarius$ pip install wheel
Collecting wheel
  Using cached wheel-0.36.2-py2.py3-none-any.whl (35 kB)
Installing collected packages: wheel
Successfully installed wheel-0.36.2
(venv) david@david-Inspiron-5502:~/projects/aquarius$ pip install --no-cache-dir -r requirements.txt 
Obtaining file:///home/david/projects/aquarius (from -r requirements.txt (line 12))
Collecting Flask-Cors==3.0.10
  Downloading Flask_Cors-3.0.10-py2.py3-none-any.whl (14 kB)
Collecting Flask==2.0.1
  Downloading Flask-2.0.1-py3-none-any.whl (94 kB)
     |████████████████████████████████| 94 kB 4.7 MB/s 
Collecting Jinja2>=2.10.1
  Downloading Jinja2-3.0.1-py3-none-any.whl (133 kB)
     |████████████████████████████████| 133 kB 6.4 MB/s 
Collecting PyYAML==5.4.1
  Downloading PyYAML-5.4.1-cp38-cp38-manylinux1_x86_64.whl (662 kB)
     |████████████████████████████████| 662 kB 6.9 MB/s 
Collecting coloredlogs==15.0.1
  Downloading coloredlogs-15.0.1-py2.py3-none-any.whl (46 kB)
     |████████████████████████████████| 46 kB 17.6 MB/s 
Collecting eciespy
  Downloading eciespy-0.3.10-py3-none-any.whl (10 kB)
Collecting flask-swagger-ui==3.36.0
  Downloading flask-swagger-ui-3.36.0.tar.gz (4.9 MB)
     |████████████████████████████████| 4.9 MB 9.4 MB/s 
Collecting flask-swagger==0.2.14
  Downloading flask-swagger-0.2.14.tar.gz (8.6 kB)
Collecting gevent
  Downloading gevent-21.1.2-cp38-cp38-manylinux2010_x86_64.whl (6.3 MB)
     |████████████████████████████████| 6.3 MB 23.0 MB/s 
Collecting gunicorn==20.1.0
  Downloading gunicorn-20.1.0-py3-none-any.whl (79 kB)
     |████████████████████████████████| 79 kB 91.5 MB/s 
Collecting json-sempai==0.4.0
  Downloading json_sempai-0.4.0-py2.py3-none-any.whl (6.2 kB)
Collecting jsonschema==3.2.0
  Downloading jsonschema-3.2.0-py2.py3-none-any.whl (56 kB)
     |████████████████████████████████| 56 kB 55.6 MB/s 
Collecting ocean-contracts==0.6.4
  Downloading ocean_contracts-0.6.4-py2.py3-none-any.whl (675 kB)
     |████████████████████████████████| 675 kB 53.7 MB/s 
Collecting oceandb-driver-interface==0.2.0
  Downloading oceandb_driver_interface-0.2.0-py2.py3-none-any.whl (11 kB)
Collecting oceandb-elasticsearch-driver==0.4.4
  Downloading oceandb_elasticsearch_driver-0.4.4-py2.py3-none-any.whl (15 kB)
Collecting python-dateutil==2.8.1
  Downloading python_dateutil-2.8.1-py2.py3-none-any.whl (227 kB)
     |████████████████████████████████| 227 kB 39.1 MB/s 
Collecting pytz==2021.1
  Downloading pytz-2021.1-py2.py3-none-any.whl (510 kB)
     |████████████████████████████████| 510 kB 60.3 MB/s 
Collecting requests>=2.21.0
  Downloading requests-2.26.0-py2.py3-none-any.whl (62 kB)
     |████████████████████████████████| 62 kB 23.7 MB/s 
Collecting web3==5.19.0
  Downloading web3-5.19.0-py3-none-any.whl (470 kB)
     |████████████████████████████████| 470 kB 102.7 MB/s 
Collecting black
  Downloading black-21.7b0-py3-none-any.whl (141 kB)
     |████████████████████████████████| 141 kB 28.1 MB/s 
Collecting bumpversion==0.6.0
  Downloading bumpversion-0.6.0-py2.py3-none-any.whl (8.4 kB)
Collecting codacy-coverage==1.3.11
  Downloading codacy_coverage-1.3.11-py2.py3-none-any.whl (7.5 kB)
Collecting coverage==5.5
  Downloading coverage-5.5-cp38-cp38-manylinux2010_x86_64.whl (245 kB)
     |████████████████████████████████| 245 kB 28.1 MB/s 
Collecting flake8
  Downloading flake8-3.9.2-py2.py3-none-any.whl (73 kB)
     |████████████████████████████████| 73 kB 44.6 MB/s 
Collecting freezegun==1.1.0
  Downloading freezegun-1.1.0-py2.py3-none-any.whl (16 kB)
Collecting isort
  Downloading isort-5.9.2-py3-none-any.whl (105 kB)
     |████████████████████████████████| 105 kB 68.3 MB/s 
Collecting licenseheaders
  Downloading licenseheaders-0.8.8-py3-none-any.whl (21 kB)
Collecting mccabe==0.6.1
  Downloading mccabe-0.6.1-py2.py3-none-any.whl (8.6 kB)
Collecting pkginfo==1.7.1
  Downloading pkginfo-1.7.1-py2.py3-none-any.whl (25 kB)
Collecting pre-commit
  Downloading pre_commit-2.13.0-py2.py3-none-any.whl (190 kB)
     |████████████████████████████████| 190 kB 29.6 MB/s 
Collecting pylint==2.9.3
  Downloading pylint-2.9.3-py3-none-any.whl (372 kB)
     |████████████████████████████████| 372 kB 27.9 MB/s 
Collecting pytest
  Downloading pytest-6.2.4-py3-none-any.whl (280 kB)
     |████████████████████████████████| 280 kB 77.7 MB/s 
Collecting pytest-env
  Downloading pytest-env-0.6.2.tar.gz (1.7 kB)
Collecting tox
  Downloading tox-3.24.0-py2.py3-none-any.whl (85 kB)
     |████████████████████████████████| 85 kB 71.0 MB/s 
Collecting twine==3.4.1
  Downloading twine-3.4.1-py3-none-any.whl (34 kB)
Collecting watchdog==2.1.3
  Downloading watchdog-2.1.3-py3-none-manylinux2014_x86_64.whl (75 kB)
     |████████████████████████████████| 75 kB 30.3 MB/s 
Collecting Six
  Downloading six-1.16.0-py2.py3-none-any.whl (11 kB)
Collecting click>=7.1.2
  Downloading click-8.0.1-py3-none-any.whl (97 kB)
     |████████████████████████████████| 97 kB 75.6 MB/s 
Collecting itsdangerous>=2.0
  Downloading itsdangerous-2.0.1-py3-none-any.whl (18 kB)
Collecting Werkzeug>=2.0
  Downloading Werkzeug-2.0.1-py3-none-any.whl (288 kB)
     |████████████████████████████████| 288 kB 28.6 MB/s 
Collecting MarkupSafe>=2.0
  Downloading MarkupSafe-2.0.1-cp38-cp38-manylinux2010_x86_64.whl (30 kB)
Collecting humanfriendly>=9.1
  Downloading humanfriendly-9.2-py2.py3-none-any.whl (86 kB)
     |████████████████████████████████| 86 kB 35.7 MB/s 
Collecting coincurve<16,>=13
  Downloading coincurve-15.0.0-cp38-cp38-manylinux2014_x86_64.whl (556 kB)
     |████████████████████████████████| 556 kB 64.7 MB/s 
Collecting pycryptodome<4.0.0,>=3.9.9
  Downloading pycryptodome-3.10.1-cp35-abi3-manylinux2010_x86_64.whl (1.9 MB)
     |████████████████████████████████| 1.9 MB 77.5 MB/s 
Collecting eth-keys<0.4.0,>=0.3.3
  Downloading eth_keys-0.3.3-py3-none-any.whl (20 kB)
Collecting zope.interface
  Downloading zope.interface-5.4.0-cp38-cp38-manylinux2010_x86_64.whl (259 kB)
     |████████████████████████████████| 259 kB 52.8 MB/s 
Requirement already satisfied: setuptools in ./venv/lib/python3.8/site-packages (from gevent->ocean-aquarius==2.2.12->-r requirements.txt (line 12)) (44.0.0)
Collecting greenlet<2.0,>=0.4.17; platform_python_implementation == "CPython"
  Downloading greenlet-1.1.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (164 kB)
     |████████████████████████████████| 164 kB 51.3 MB/s 
Collecting zope.event
  Downloading zope.event-4.5.0-py2.py3-none-any.whl (6.8 kB)
Collecting pyrsistent>=0.14.0
  Downloading pyrsistent-0.18.0-cp38-cp38-manylinux1_x86_64.whl (118 kB)
     |████████████████████████████████| 118 kB 57.2 MB/s 
Collecting attrs>=17.4.0
  Downloading attrs-21.2.0-py2.py3-none-any.whl (53 kB)
     |████████████████████████████████| 53 kB 48.7 MB/s 
Collecting elasticsearch
  Downloading elasticsearch-7.13.3-py2.py3-none-any.whl (356 kB)
     |████████████████████████████████| 356 kB 75.2 MB/s 
Collecting certifi>=2017.4.17
  Downloading certifi-2021.5.30-py2.py3-none-any.whl (145 kB)
     |████████████████████████████████| 145 kB 28.6 MB/s 
Collecting idna<4,>=2.5; python_version >= "3"
  Downloading idna-3.2-py3-none-any.whl (59 kB)
     |████████████████████████████████| 59 kB 71.3 MB/s 
Collecting urllib3<1.27,>=1.21.1
  Downloading urllib3-1.26.6-py2.py3-none-any.whl (138 kB)
     |████████████████████████████████| 138 kB 44.5 MB/s 
Collecting charset-normalizer~=2.0.0; python_version >= "3"
  Downloading charset_normalizer-2.0.3-py3-none-any.whl (35 kB)
Collecting eth-typing<3.0.0,>=2.0.0
  Downloading eth_typing-2.2.2-py3-none-any.whl (6.2 kB)
Collecting ipfshttpclient==0.7.0a1
  Downloading ipfshttpclient-0.7.0a1-py3-none-any.whl (231 kB)
     |████████████████████████████████| 231 kB 48.5 MB/s 
Collecting hexbytes<1.0.0,>=0.1.0
  Downloading hexbytes-0.2.1-py3-none-any.whl (6.0 kB)
Collecting lru-dict<2.0.0,>=1.1.6
  Downloading lru-dict-1.1.7.tar.gz (10 kB)
Collecting eth-account<0.6.0,>=0.5.3
  Downloading eth_account-0.5.4-py3-none-any.whl (94 kB)
     |████████████████████████████████| 94 kB 52.9 MB/s 
Collecting eth-abi<3.0.0,>=2.0.0b6
  Downloading eth_abi-2.1.1-py3-none-any.whl (27 kB)
Collecting websockets<9.0.0,>=8.1.0
  Downloading websockets-8.1-cp38-cp38-manylinux2010_x86_64.whl (78 kB)
     |████████████████████████████████| 78 kB 81.1 MB/s 
Collecting protobuf<4,>=3.10.0
  Downloading protobuf-3.17.3-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.whl (1.0 MB)
     |████████████████████████████████| 1.0 MB 82.3 MB/s 
Collecting eth-utils<2.0.0,>=1.9.5
  Downloading eth_utils-1.10.0-py3-none-any.whl (24 kB)
Collecting eth-hash[pycryptodome]<1.0.0,>=0.2.0
  Downloading eth_hash-0.3.1-py3-none-any.whl (8.9 kB)
Collecting regex>=2020.1.8
  Downloading regex-2021.7.6-cp38-cp38-manylinux2014_x86_64.whl (737 kB)
     |████████████████████████████████| 737 kB 95.9 MB/s 
Collecting appdirs
  Downloading appdirs-1.4.4-py2.py3-none-any.whl (9.6 kB)
Collecting mypy-extensions>=0.4.3
  Downloading mypy_extensions-0.4.3-py2.py3-none-any.whl (4.5 kB)
Collecting tomli<2.0.0,>=0.2.6
  Downloading tomli-1.0.4-py3-none-any.whl (11 kB)
Collecting pathspec<1,>=0.8.1
  Downloading pathspec-0.9.0-py2.py3-none-any.whl (31 kB)
Collecting bump2version
  Downloading bump2version-1.0.1-py2.py3-none-any.whl (22 kB)
Collecting pycodestyle<2.8.0,>=2.7.0
  Downloading pycodestyle-2.7.0-py2.py3-none-any.whl (41 kB)
     |████████████████████████████████| 41 kB 10.3 MB/s 
Collecting pyflakes<2.4.0,>=2.3.0
  Downloading pyflakes-2.3.1-py2.py3-none-any.whl (68 kB)
     |████████████████████████████████| 68 kB 28.6 MB/s 
Collecting toml
  Downloading toml-0.10.2-py2.py3-none-any.whl (16 kB)
Collecting identify>=1.0.0
  Downloading identify-2.2.11-py2.py3-none-any.whl (98 kB)
     |████████████████████████████████| 98 kB 36.7 MB/s 
Collecting virtualenv>=20.0.8
  Downloading virtualenv-20.6.0-py2.py3-none-any.whl (5.3 MB)
     |████████████████████████████████| 5.3 MB 83.0 MB/s 
Collecting cfgv>=2.0.0
  Downloading cfgv-3.3.0-py2.py3-none-any.whl (7.3 kB)
Collecting nodeenv>=0.11.1
  Downloading nodeenv-1.6.0-py2.py3-none-any.whl (21 kB)
Collecting astroid<2.7,>=2.6.2
  Downloading astroid-2.6.2-py3-none-any.whl (228 kB)
     |████████████████████████████████| 228 kB 28.9 MB/s 
Collecting iniconfig
  Downloading iniconfig-1.1.1-py2.py3-none-any.whl (5.0 kB)
Collecting py>=1.8.2
  Downloading py-1.10.0-py2.py3-none-any.whl (97 kB)
     |████████████████████████████████| 97 kB 82.2 MB/s 
Collecting pluggy<1.0.0a1,>=0.12
  Downloading pluggy-0.13.1-py2.py3-none-any.whl (18 kB)
Collecting packaging
  Downloading packaging-21.0-py3-none-any.whl (40 kB)
     |████████████████████████████████| 40 kB 55.1 MB/s 
Collecting filelock>=3.0.0
  Downloading filelock-3.0.12-py3-none-any.whl (7.6 kB)
Collecting rfc3986>=1.4.0
  Downloading rfc3986-1.5.0-py2.py3-none-any.whl (31 kB)
Collecting tqdm>=4.14
  Downloading tqdm-4.61.2-py2.py3-none-any.whl (76 kB)
     |████████████████████████████████| 76 kB 40.9 MB/s 
Collecting colorama>=0.4.3
  Downloading colorama-0.4.4-py2.py3-none-any.whl (16 kB)
Collecting importlib-metadata>=3.6
  Downloading importlib_metadata-4.6.1-py3-none-any.whl (17 kB)
Collecting readme-renderer>=21.0
  Downloading readme_renderer-29.0-py2.py3-none-any.whl (15 kB)
Collecting requests-toolbelt!=0.9.0,>=0.8.0
  Downloading requests_toolbelt-0.9.1-py2.py3-none-any.whl (54 kB)
     |████████████████████████████████| 54 kB 73.7 MB/s 
Collecting keyring>=15.1
  Downloading keyring-23.0.1-py3-none-any.whl (33 kB)
Collecting cffi>=1.3.0
  Downloading cffi-1.14.6-cp38-cp38-manylinux1_x86_64.whl (411 kB)
     |████████████████████████████████| 411 kB 55.5 MB/s 
Collecting asn1crypto
  Downloading asn1crypto-1.4.0-py2.py3-none-any.whl (104 kB)
     |████████████████████████████████| 104 kB 71.9 MB/s 
Collecting multiaddr>=0.0.7
  Downloading multiaddr-0.0.9-py2.py3-none-any.whl (16 kB)
Collecting eth-keyfile<0.6.0,>=0.5.0
  Downloading eth_keyfile-0.5.1-py3-none-any.whl (8.3 kB)
Collecting rlp<3,>=1.0.0
  Downloading rlp-2.0.1-py2.py3-none-any.whl (20 kB)
Collecting eth-rlp<2,>=0.1.2
  Downloading eth_rlp-0.2.1-py3-none-any.whl (5.0 kB)
Collecting bitarray<1.3.0,>=1.2.1
  Downloading bitarray-1.2.2.tar.gz (48 kB)
     |████████████████████████████████| 48 kB 76.1 MB/s 
Collecting parsimonious<0.9.0,>=0.8.0
  Downloading parsimonious-0.8.1.tar.gz (45 kB)
     |████████████████████████████████| 45 kB 32.6 MB/s 
Collecting cytoolz<1.0.0,>=0.10.1; implementation_name == "cpython"
  Downloading cytoolz-0.11.0.tar.gz (477 kB)
     |████████████████████████████████| 477 kB 67.7 MB/s 
Collecting backports.entry-points-selectable>=1.0.4
  Downloading backports.entry_points_selectable-1.1.0-py2.py3-none-any.whl (6.2 kB)
Collecting platformdirs<3,>=2
  Downloading platformdirs-2.0.2-py2.py3-none-any.whl (10 kB)
Collecting distlib<1,>=0.3.1
  Downloading distlib-0.3.2-py2.py3-none-any.whl (338 kB)
     |████████████████████████████████| 338 kB 77.6 MB/s 
Collecting wrapt<1.13,>=1.11
  Downloading wrapt-1.12.1.tar.gz (27 kB)
Collecting lazy-object-proxy>=1.4.0
  Downloading lazy_object_proxy-1.6.0-cp38-cp38-manylinux1_x86_64.whl (58 kB)
     |████████████████████████████████| 58 kB 53.3 MB/s 
Collecting pyparsing>=2.0.2
  Downloading pyparsing-2.4.7-py2.py3-none-any.whl (67 kB)
     |████████████████████████████████| 67 kB 42.8 MB/s 
Collecting zipp>=0.5
  Downloading zipp-3.5.0-py3-none-any.whl (5.7 kB)
Collecting bleach>=2.1.0
  Downloading bleach-3.3.1-py2.py3-none-any.whl (146 kB)
     |████████████████████████████████| 146 kB 33.7 MB/s 
Collecting docutils>=0.13.1
  Downloading docutils-0.17.1-py2.py3-none-any.whl (575 kB)
     |████████████████████████████████| 575 kB 56.1 MB/s 
Collecting Pygments>=2.5.1
  Downloading Pygments-2.9.0-py3-none-any.whl (1.0 MB)
     |████████████████████████████████| 1.0 MB 64.7 MB/s 
Collecting SecretStorage>=3.2; sys_platform == "linux"
  Downloading SecretStorage-3.3.1-py3-none-any.whl (15 kB)
Collecting jeepney>=0.4.2; sys_platform == "linux"
  Downloading jeepney-0.7.0-py3-none-any.whl (53 kB)
     |████████████████████████████████| 53 kB 44.4 MB/s 
Collecting pycparser
  Downloading pycparser-2.20-py2.py3-none-any.whl (112 kB)
     |████████████████████████████████| 112 kB 48.3 MB/s 
Collecting base58
  Downloading base58-2.1.0-py3-none-any.whl (5.6 kB)
Collecting varint
  Downloading varint-1.0.2.tar.gz (1.9 kB)
Collecting netaddr
  Downloading netaddr-0.8.0-py2.py3-none-any.whl (1.9 MB)
     |████████████████████████████████| 1.9 MB 69.5 MB/s 
Collecting toolz>=0.8.0
  Downloading toolz-0.11.1-py3-none-any.whl (55 kB)
     |████████████████████████████████| 55 kB 25.4 MB/s 
Collecting webencodings
  Downloading webencodings-0.5.1-py2.py3-none-any.whl (11 kB)
Collecting cryptography>=2.0
  Downloading cryptography-3.4.7-cp36-abi3-manylinux2014_x86_64.whl (3.2 MB)
     |████████████████████████████████| 3.2 MB 84.3 MB/s 
Building wheels for collected packages: flask-swagger-ui, flask-swagger, pytest-env, lru-dict, bitarray, parsimonious, cytoolz, wrapt, varint
  Building wheel for flask-swagger-ui (setup.py) ... done
  Created wheel for flask-swagger-ui: filename=flask_swagger_ui-3.36.0-py3-none-any.whl size=4955827 sha256=250c9d90aac4091ce1c25b7993f1fb076dcc6defdd0fab8e5115f93d6f140be2
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/69/ce/07/2361a747d34780afa5fc2d45a1703df920f73905a7f009ce0b
  Building wheel for flask-swagger (setup.py) ... done
  Created wheel for flask-swagger: filename=flask_swagger-0.2.14-py3-none-any.whl size=7267 sha256=f37758828fd881770d26fd517529a6e89db2958394430f2d0ade870b32a2e827
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/66/4d/fe/bfaf9b89c8db3b29f52c01cb9bd050f68e67195747b5dda118
  Building wheel for pytest-env (setup.py) ... done
  Created wheel for pytest-env: filename=pytest_env-0.6.2-py3-none-any.whl size=2370 sha256=7e3e1ad2a3a40c94758039e2ef70e8bee1328b6a56e8e8a833a03c3127d7cabb
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/37/01/73/bbe6b92b251c90dbe27c15b8e5b57085b9b53dfe018e9b6cea
  Building wheel for lru-dict (setup.py) ... done
  Created wheel for lru-dict: filename=lru_dict-1.1.7-cp38-cp38-linux_x86_64.whl size=31300 sha256=4a6e8cea0db46181b981f90b639952b3e20e04d972bfdaa6cd788b127cad07df
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/ab/ed/82/d47759a6e2416fb78d6ee81c02a970a50d5dc6fc270b5a3242
  Building wheel for bitarray (setup.py) ... done
  Created wheel for bitarray: filename=bitarray-1.2.2-cp38-cp38-linux_x86_64.whl size=117756 sha256=d465430a0313c6bfeb15368b6f0a325f3244d4ecf72a492b777041827482cf62
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/41/36/95/5b4eca059535a8400e8f4ca38f4883ea1801bb221fbd8170df
  Building wheel for parsimonious (setup.py) ... done
  Created wheel for parsimonious: filename=parsimonious-0.8.1-py3-none-any.whl size=42709 sha256=5aa514d033f36ff9879ac62b146b39ff41f2b3bd84fb3581ca8016e2c732ce47
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/d8/af/19/fb896f509a437aca2dcf62583e84d7fb2cd5b628c1564a609c
  Building wheel for cytoolz (setup.py) ... done
  Created wheel for cytoolz: filename=cytoolz-0.11.0-cp38-cp38-linux_x86_64.whl size=1912179 sha256=a86478a5b25ed1aa717acffd51c374acc3721060313246cb8cc49bbc207ddc71
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/12/80/98/b62b7fba2c0b84c34d515324548a3205c078ae0109293fb617
  Building wheel for wrapt (setup.py) ... done
  Created wheel for wrapt: filename=wrapt-1.12.1-cp38-cp38-linux_x86_64.whl size=78523 sha256=22bcaafaac16a4ff007dff4ca195ee54a6b27419678b8243398fae00e1cab07a
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/5f/fd/9e/b6cf5890494cb8ef0b5eaff72e5d55a70fb56316007d6dfe73
  Building wheel for varint (setup.py) ... done
  Created wheel for varint: filename=varint-1.0.2-py3-none-any.whl size=1978 sha256=c491713ef8259f1c6ad6507b729370e1ee537c288220f677bd6f48e2ed5c7d71
  Stored in directory: /tmp/pip-ephem-wheel-cache-hsqjvwkx/wheels/cc/a8/a4/4d9e9807c27585dc974fc0e86a3e4345649d71f8a35906d1a8
Successfully built flask-swagger-ui flask-swagger pytest-env lru-dict bitarray parsimonious cytoolz wrapt varint
Installing collected packages: Six, click, MarkupSafe, Jinja2, itsdangerous, Werkzeug, Flask, Flask-Cors, PyYAML, humanfriendly, coloredlogs, pycparser, cffi, asn1crypto, coincurve, pycryptodome, eth-typing, toolz, cytoolz, eth-hash, eth-utils, eth-keys, eciespy, flask-swagger-ui, flask-swagger, zope.interface, greenlet, zope.event, gevent, gunicorn, json-sempai, pyrsistent, attrs, jsonschema, ocean-contracts, oceandb-driver-interface, certifi, urllib3, elasticsearch, oceandb-elasticsearch-driver, python-dateutil, pytz, idna, charset-normalizer, requests, base58, varint, netaddr, multiaddr, ipfshttpclient, hexbytes, lru-dict, eth-keyfile, parsimonious, eth-abi, rlp, eth-rlp, bitarray, eth-account, websockets, protobuf, web3, regex, appdirs, mypy-extensions, tomli, pathspec, black, bump2version, bumpversion, codacy-coverage, coverage, pycodestyle, mccabe, pyflakes, flake8, freezegun, isort, licenseheaders, pkginfo, toml, identify, filelock, backports.entry-points-selectable, platformdirs, distlib, virtualenv, cfgv, nodeenv, pre-commit, wrapt, lazy-object-proxy, astroid, pylint, iniconfig, py, pluggy, pyparsing, packaging, pytest, pytest-env, tox, rfc3986, tqdm, colorama, zipp, importlib-metadata, webencodings, bleach, docutils, Pygments, readme-renderer, requests-toolbelt, cryptography, jeepney, SecretStorage, keyring, twine, watchdog, ocean-aquarius
  Running setup.py develop for ocean-aquarius
Successfully installed Flask-2.0.1 Flask-Cors-3.0.10 Jinja2-3.0.1 MarkupSafe-2.0.1 PyYAML-5.4.1 Pygments-2.9.0 SecretStorage-3.3.1 Six-1.16.0 Werkzeug-2.0.1 appdirs-1.4.4 asn1crypto-1.4.0 astroid-2.6.2 attrs-21.2.0 backports.entry-points-selectable-1.1.0 base58-2.1.0 bitarray-1.2.2 black-21.7b0 bleach-3.3.1 bump2version-1.0.1 bumpversion-0.6.0 certifi-2021.5.30 cffi-1.14.6 cfgv-3.3.0 charset-normalizer-2.0.3 click-8.0.1 codacy-coverage-1.3.11 coincurve-15.0.0 colorama-0.4.4 coloredlogs-15.0.1 coverage-5.5 cryptography-3.4.7 cytoolz-0.11.0 distlib-0.3.2 docutils-0.17.1 eciespy-0.3.10 elasticsearch-7.13.3 eth-abi-2.1.1 eth-account-0.5.4 eth-hash-0.3.1 eth-keyfile-0.5.1 eth-keys-0.3.3 eth-rlp-0.2.1 eth-typing-2.2.2 eth-utils-1.10.0 filelock-3.0.12 flake8-3.9.2 flask-swagger-0.2.14 flask-swagger-ui-3.36.0 freezegun-1.1.0 gevent-21.1.2 greenlet-1.1.0 gunicorn-20.1.0 hexbytes-0.2.1 humanfriendly-9.2 identify-2.2.11 idna-3.2 importlib-metadata-4.6.1 iniconfig-1.1.1 ipfshttpclient-0.7.0a1 isort-5.9.2 itsdangerous-2.0.1 jeepney-0.7.0 json-sempai-0.4.0 jsonschema-3.2.0 keyring-23.0.1 lazy-object-proxy-1.6.0 licenseheaders-0.8.8 lru-dict-1.1.7 mccabe-0.6.1 multiaddr-0.0.9 mypy-extensions-0.4.3 netaddr-0.8.0 nodeenv-1.6.0 ocean-aquarius ocean-contracts-0.6.4 oceandb-driver-interface-0.2.0 oceandb-elasticsearch-driver-0.4.4 packaging-21.0 parsimonious-0.8.1 pathspec-0.9.0 pkginfo-1.7.1 platformdirs-2.0.2 pluggy-0.13.1 pre-commit-2.13.0 protobuf-3.17.3 py-1.10.0 pycodestyle-2.7.0 pycparser-2.20 pycryptodome-3.10.1 pyflakes-2.3.1 pylint-2.9.3 pyparsing-2.4.7 pyrsistent-0.18.0 pytest-6.2.4 pytest-env-0.6.2 python-dateutil-2.8.1 pytz-2021.1 readme-renderer-29.0 regex-2021.7.6 requests-2.26.0 requests-toolbelt-0.9.1 rfc3986-1.5.0 rlp-2.0.1 toml-0.10.2 tomli-1.0.4 toolz-0.11.1 tox-3.24.0 tqdm-4.61.2 twine-3.4.1 urllib3-1.26.6 varint-1.0.2 virtualenv-20.6.0 watchdog-2.1.3 web3-5.19.0 webencodings-0.5.1 websockets-8.1 wrapt-1.12.1 zipp-3.5.0 zope.event-4.5.0 zope.interface-5.4.0
(venv) david@david-Inspiron-5502:~/projects/aquarius$ 
```

</p>
</details>