### PR TITLE
Bump version: 3.0.2 → 3.1.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 3.0.2
+current_version = 3.1.0
 commit = True
 tag = True
 

--- a/aquarius/__init__.py
+++ b/aquarius/__init__.py
@@ -9,5 +9,5 @@
 __author__ = """OceanProtocol"""
 # fmt: off
 # bumpversion needs single quotes
-__version__ = '3.0.2'
+__version__ = '3.1.0'
 # fmt: on

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,7 @@ setup(
     url="https://github.com/oceanprotocol/aquarius",
     # fmt: off
     # bumpversion needs single quotes
-    version='3.0.2',
+    version='3.1.0',
     # fmt: on
     zip_safe=False,
 )


### PR DESCRIPTION
Since we broke endpoints, we should release a new minor version, and not just a patch increment.
