### PR TITLE
Move isPurgatory field to stats field in aqua ddo asset

### DIFF
--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -98,6 +98,9 @@ class EventProcessor(ABC):
         record["datatokens"] = self.get_tokens_info()
         # TODO: record["stats"]["consumes"]
 
+        # Initialise stats field
+        record["stats"] = {}
+
         return record, block_time
 
     def get_tokens_info(self):
@@ -149,9 +152,9 @@ class MetadataCreatedProcessor(EventProcessor):
             return False
 
         if self.purgatory and self.purgatory.is_account_banned(self.sender_address):
-            _record["isInPurgatory"] = "true"
+            _record["stats"]["isInPurgatory"] = "true"
         else:
-            _record["isInPurgatory"] = "false"
+            _record["stats"]["isInPurgatory"] = "false"
 
         return _record
 
@@ -231,9 +234,11 @@ class MetadataUpdatedProcessor(EventProcessor):
 
         # check purgatory only if asset is valid
         if self.purgatory and self.purgatory.is_account_banned(self.sender_address):
-            _record["isInPurgatory"] = "true"
+            _record["stats"]["isInPurgatory"] = "true"
         else:
-            _record["isInPurgatory"] = old_asset.get("isInPurgatory", "false")
+            _record["stats"]["isInPurgatory"] = old_asset.get("stats", "false").get(
+                "isInPurgatory", "false"
+            )
 
         return _record
 

--- a/aquarius/events/purgatory.py
+++ b/aquarius/events/purgatory.py
@@ -42,10 +42,10 @@ class Purgatory:
 
     def update_asset_purgatory_status(self, asset, purgatory="true"):
         """
-        Updates the field `isInPurgatory` of `asset` object.
+        Updates the field `isInPurgatory`of field `stats` in `asset` object.
         """
         did = asset["id"]
-        asset["isInPurgatory"] = purgatory
+        asset["stats"]["isInPurgatory"] = purgatory
         logger.info(f"PURGATORY: updating asset {did} with value {purgatory}.")
         try:
             self._es_instance.update(json.dumps(asset), did)

--- a/tests/test_purgatory.py
+++ b/tests/test_purgatory.py
@@ -68,18 +68,18 @@ def test_purgatory_with_assets(client, base_ddo_url, events_object, monkeypatch)
 
     purgatory = PurgatoryForTesting(events_object._es_instance)
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "false"
+    assert published_ddo["stats"]["isInPurgatory"] == "false"
 
     purgatory.current_test_asset_list = {(did, "test_reason")}
     purgatory.update_lists()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "true"
+    assert published_ddo["stats"]["isInPurgatory"] == "true"
 
     # remove did from purgatory, but before 1h passed (won't have an effect)
     purgatory.current_test_asset_list = set()
     purgatory.update_lists()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "true"
+    assert published_ddo["stats"]["isInPurgatory"] == "true"
 
     # simulate the passage of time (1 hour until next purgatory update)
     in_one_hour = datetime.now() + timedelta(hours=1)
@@ -90,7 +90,7 @@ def test_purgatory_with_assets(client, base_ddo_url, events_object, monkeypatch)
     purgatory.update_lists()
     freezer.stop()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "false"
+    assert published_ddo["stats"]["isInPurgatory"] == "false"
 
 
 def test_purgatory_with_accounts(client, base_ddo_url, events_object, monkeypatch):
@@ -106,19 +106,19 @@ def test_purgatory_with_accounts(client, base_ddo_url, events_object, monkeypatc
 
     purgatory = PurgatoryForTesting(events_object._es_instance)
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "false"
+    assert published_ddo["stats"]["isInPurgatory"] == "false"
 
     acc_id = events_object._es_instance.read(did)["event"]["from"]
     purgatory.current_test_account_list = {(acc_id, "test_reason")}
     purgatory.update_lists()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "true"
+    assert published_ddo["stats"]["isInPurgatory"] == "true"
 
     # remove account from purgatory, but before 1h passed (won't have an effect)
     purgatory.current_test_account_list = set()
     purgatory.update_lists()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "true"
+    assert published_ddo["stats"]["isInPurgatory"] == "true"
 
     # simulate the passage of time (1 hour until next purgatory update)
     in_one_hour = datetime.now() + timedelta(hours=1)
@@ -129,7 +129,7 @@ def test_purgatory_with_accounts(client, base_ddo_url, events_object, monkeypatc
     purgatory.update_lists()
     freezer.stop()
     published_ddo = get_ddo(client, base_ddo_url, did)
-    assert published_ddo["isInPurgatory"] == "false"
+    assert published_ddo["stats"]["isInPurgatory"] == "false"
 
 
 def test_purgatory_retrieve_new_list(events_object):
@@ -152,7 +152,7 @@ def test_failures(events_object):
     purgatory = Purgatory(events_object._es_instance)
     with patch("aquarius.app.es_instance.ElasticsearchInstance.update") as mock:
         mock.side_effect = Exception("Boom!")
-        purgatory.update_asset_purgatory_status({"id": "id"})
+        purgatory.update_asset_purgatory_status({"id": "id", "stats": {}})
 
 
 def test_is_account_banned(events_object):


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->

Fixes #621 .

- Move IsPurgatory field to stats field in ddo aqua asset
- Update tests
