### PR TITLE
Update NFT state field in ES when MetadaState event received

### DIFF
--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -122,7 +122,7 @@ class EventProcessor(ABC):
         }
         return self._es_instance.update(soft_deleted_asset, did)
 
-    def update_aqua_ntf_state_data(self, new_state: str, did: str):
+    def update_aqua_nft_state_data(self, new_state: str, did: str):
         """Updates NFT state field from the aquarius custom fields data listed in AquariusCustomDDOFields for a given
         DID"""
         asset_to_update = self._es_instance.read(did)
@@ -387,7 +387,7 @@ class MetadataStateProcessor(EventProcessor):
             try:
                 self._es_instance.read(self.did)
                 self.soft_delete_ddo(self.did)
-                self.update_aqua_ntf_state_data(self.event.args.state, self.did)
+                self.update_aqua_nft_state_data(self.event.args.state, self.did)
             except Exception:
                 pass
             return

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -122,6 +122,13 @@ class EventProcessor(ABC):
         }
         return self._es_instance.update(soft_deleted_asset, did)
 
+    def update_aqua_ntf_state_data(self, new_state: str, did: str):
+        """Updates NFT state field from the aquarius custom fields data listed in AquariusCustomDDOFields for a given
+        DID"""
+        asset_to_update = self._es_instance.read(did)
+        asset_to_update[AquariusCustomDDOFields.NFT]["state"] = new_state
+        return self._es_instance.update(asset_to_update, did)
+
     def get_tokens_info(self, record):
         datatokens = []
         for service in record.get("services"):
@@ -380,6 +387,7 @@ class MetadataStateProcessor(EventProcessor):
             try:
                 self._es_instance.read(self.did)
                 self.soft_delete_ddo(self.did)
+                self.update_aqua_ntf_state_data(self.event.args.state, self.did)
             except Exception:
                 pass
             return

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -299,7 +299,13 @@ def test_metadata_state_update(client, base_ddo_url, events_object):
     # Check if asset is soft deleted
     assert "id" not in published_ddo
     assert list(published_ddo.keys()) == AquariusCustomDDOFields.get_all_values()
-    assert published_ddo["event"]["tx"] == initial_ddo["event"]["tx"]
+    assert (
+        published_ddo[AquariusCustomDDOFields.EVENT]["tx"]
+        == initial_ddo[AquariusCustomDDOFields.EVENT]["tx"]
+    )
+    assert (
+        published_ddo[AquariusCustomDDOFields.NFT]["state"] == MetadataStates.DEPRECATED
+    )
 
     # MetadataState updated to active should delegate to MetadataCreated processor
     # and recreate asset
@@ -312,3 +318,5 @@ def test_metadata_state_update(client, base_ddo_url, events_object):
     assert published_ddo["id"] == did
     # The event after recreation is kept as it uses the same original creation event
     assert published_ddo["event"]["tx"] == initial_ddo["event"]["tx"]
+    # The NFT state is active
+    assert published_ddo[AquariusCustomDDOFields.NFT]["state"] == MetadataStates.ACTIVE

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -6,6 +6,7 @@ import json
 from unittest.mock import patch
 
 import elasticsearch
+import time
 from jsonsempai import magic  # noqa: F401
 
 from aquarius.events.constants import AquariusCustomDDOFields, MetadataStates
@@ -313,6 +314,7 @@ def test_metadata_state_update(client, base_ddo_url, events_object):
         ddo=_ddo, account=test_account1, state=MetadataStates.ACTIVE
     )
     events_object.process_current_blocks()
+    time.sleep(5)
     published_ddo = get_ddo(client, base_ddo_url, did)
     # Asset has been recreated
     assert published_ddo["id"] == did


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
Fixes issue #632 .

Changes proposed in this PR:

- Update NTF state field in ES when a `MetadaState` event is received and the state is other than active 
