### PR TITLE
Mirror setup.py updates from main.

### DIFF
--- a/aquarius/events/util.py
+++ b/aquarius/events/util.py
@@ -74,7 +74,7 @@ def deploy_datatoken(w3, account, name, symbol):
 
     built_tx = dt_factory.functions.deployERC721Contract(
         name, symbol, 1, "0x0000000000000000000000000000000000000000", ""
-    ).buildTransaction({"from": account.address})
+    ).buildTransaction({"from": account.address, "gasPrice": w3.eth.gas_price})
 
     raw_tx = sign_tx(w3, built_tx, account.key)
     tx_hash = w3.eth.send_raw_transaction(raw_tx)

--- a/aquarius/events/util.py
+++ b/aquarius/events/util.py
@@ -118,16 +118,18 @@ def get_address_file():
 
 def get_metadata_start_block():
     """Returns the block number to use as start"""
-    # TODO
-    return 0
     block_number = int(os.getenv("METADATA_CONTRACT_BLOCK", 0))
     if not block_number:
         address_file = get_address_file()
         with open(address_file) as f:
             address_json = json.load(f)
         network = get_network_name()
+        # TODO: this is still a dependency from barge,
+        # the key will probably have a different name so it needs update
         if "startBlock" in address_json[network]:
             block_number = address_json[network]["startBlock"]
+        else:
+            block_number = 0
 
     return block_number
 

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ install_requirements = [
     "pytz==2021.3",
     # temporarily removed
     # "ocean-contracts==0.6.9",
-    "web3==5.24.0",
+    "web3==5.25.0",
     "gevent",
     "json-sempai==0.4.0",
     "python-dateutil==2.8.2",

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requirements = [
     "Jinja2>=2.10.1",
     "requests>=2.21.0",
     "gunicorn==20.1.0",
-    "elasticsearch==7.15.1",
+    "elasticsearch==7.15.2",
     "PyYAML==6.0",
     "pytz==2021.3",
     # temporarily removed
@@ -44,8 +44,8 @@ setup_requirements = ["pytest-runner==5.3.1"]
 
 dev_requirements = [
     "bumpversion==0.6.0",
-    "pkginfo==1.7.1",
-    "twine==3.4.2",
+    "pkginfo==1.8.1",
+    "twine==3.6.0",
     "flake8",
     "isort",
     "black",
@@ -58,9 +58,9 @@ dev_requirements = [
 test_requirements = [
     "Flask==2.0.2",
     "codacy-coverage==1.3.11",
-    "coverage==6.0.2",
+    "coverage==6.2",
     "mccabe==0.6.1",
-    "pylint==2.11.1",
+    "pylint==2.12.1",
     "pytest",
     "tox",
     "pytest-env",


### PR DESCRIPTION
- syncs up the package upgrades from main
- upgrades web3 package and fixes the new fee issue with buildTransaction: https://stackoverflow.com/questions/70051896/python-web3-and-ganache-error-method-eth-maxpriorityfeepergas-not-supported. [supersedes https://github.com/oceanprotocol/aquarius/pull/630]
- minor cosmetic improvement of the metadata start block TODO