### PR TITLE
Make nonce a str

### DIFF
--- a/aquarius/events/decryptor.py
+++ b/aquarius/events/decryptor.py
@@ -12,7 +12,7 @@ from eth_account.messages import encode_defunct
 
 def decrypt_ddo(w3, provider_url, contract_address, chain_id, txid):
     aquarius_account = Account.from_key(os.environ.get("PRIVATE_KEY"))
-    nonce = datetime.now().timestamp()
+    nonce = str(datetime.now().timestamp())
     signature = aquarius_account.sign_message(
         encode_defunct(text=f"{txid}{aquarius_account.address}{chain_id}{nonce}")
     ).signature.hex()


### PR DESCRIPTION
This change is based on the `decrypt` endpoint unit tests in provider.

https://github.com/oceanprotocol/provider/blob/v4main/tests/test_encryption.py#L331-335
```python
    nonce = str(datetime.now().timestamp())
    message_to_be_signed = (
        f"{set_metadata_tx_id}{decrypter_wallet.address}{chain_id}{nonce}"
    )
    signature = sign_message(message_to_be_signed, decrypter_wallet)
```