### PR TITLE
improvements

### DIFF
--- a/aquarius/events/decryptor.py
+++ b/aquarius/events/decryptor.py
@@ -14,7 +14,8 @@ from hashlib import sha256
 def decrypt_ddo(w3, provider_url, contract_address, chain_id, txid, hash):
     pk = os.environ.get("PRIVATE_KEY", None)
     if pk is None:
-        raise Exception(f"Missing Aquarius PRIVATE_KEY")
+        raise Exception("Missing Aquarius PRIVATE_KEY")
+
     aquarius_account = Account.from_key(pk)
     nonce = str(datetime.now().timestamp())
     signature = aquarius_account.sign_message(

--- a/aquarius/events/decryptor.py
+++ b/aquarius/events/decryptor.py
@@ -8,10 +8,14 @@ import os
 import requests
 from eth_account import Account
 from eth_account.messages import encode_defunct
+from hashlib import sha256
 
 
-def decrypt_ddo(w3, provider_url, contract_address, chain_id, txid):
-    aquarius_account = Account.from_key(os.environ.get("PRIVATE_KEY"))
+def decrypt_ddo(w3, provider_url, contract_address, chain_id, txid, hash):
+    pk = os.environ.get("PRIVATE_KEY", None)
+    if pk is None:
+        raise Exception(f"Missing Aquarius PRIVATE_KEY")
+    aquarius_account = Account.from_key(pk)
     nonce = str(datetime.now().timestamp())
     signature = aquarius_account.sign_message(
         encode_defunct(text=f"{txid}{aquarius_account.address}{chain_id}{nonce}")
@@ -26,7 +30,10 @@ def decrypt_ddo(w3, provider_url, contract_address, chain_id, txid):
     }
 
     response = requests.post(provider_url + "/api/services/decrypt", json=payload)
+
     if response.status_code == 201:
+        if sha256(response.text.encode("utf-8")).hexdigest() != hash.hex():
+            raise Exception(f"Hash check failed")
         return response.json()
 
     raise Exception(f"Provider exception on decrypt DDO: {response.content}")

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -88,9 +88,9 @@ class EventProcessor(ABC):
 
         record[AquariusCustomDDOFields.NFT] = {
             "address": self.dt_contract.address,
-            "name": self.get_token_name(self.dt_contract),
-            "symbol": self.get_token_symbol(self.dt_contract),
-            "state": self.get_nft_metaDataState(),
+            "name": self._get_contract_attribute(self.dt_contract, "name"),
+            "symbol": self._get_contract_attribute(self.dt_contract, "symbol"),
+            "state": self._get_contract_attribute(self.dt_contract, "metaDataState"),
             "owner": self.get_nft_owner(),
         }
 
@@ -131,38 +131,20 @@ class EventProcessor(ABC):
             datatokens.append(
                 {
                     "address": service["datatokenAddress"],
-                    "name": self.get_token_name(token_contract),
-                    "symbol": self.get_token_symbol(token_contract),
+                    "name": self._get_contract_attribute(token_contract, "name"),
+                    "symbol": self._get_contract_attribute(token_contract, "symbol"),
                     "serviceId": service["id"],
                 }
             )
 
         return datatokens
 
-    def get_token_name(self, contract):
+    def _get_contract_attribute(self, contract, attr_name):
         data = ""
         try:
-            data = contract.caller.name()
+            data = getattr(contract.caller, attr_name)()
         except Exception as e:
-            logger.warn(f"Cannot get token name: {e}")
-            pass
-        return data
-
-    def get_token_symbol(self, contract):
-        data = ""
-        try:
-            data = contract.caller.symbol()
-        except Exception as e:
-            logger.warn(f"Cannot get token symbol: {e}")
-            pass
-        return data
-
-    def get_nft_metaDataState(self):
-        data = ""
-        try:
-            data = self.dt_contract.caller.metaDataState()
-        except Exception as e:
-            logger.warn(f"Cannot get NFT metaDataState: {e}")
+            logger.warn(f"Cannot get token {attr_name}: {e}")
             pass
         return data
 

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -8,12 +8,10 @@ import logging
 import os
 from abc import ABC
 from datetime import datetime
-from hashlib import sha256
 
 import requests
 from jsonsempai import magic  # noqa: F401
 
-from aquarius.app.auth_util import compare_eth_addresses
 from aquarius.ddo_checker.shacl_checker import validate_dict
 from aquarius.events.constants import (
     AquariusCustomDDOFields,
@@ -74,12 +72,6 @@ class EventProcessor(ABC):
         except Exception:
             return False
 
-    def check_document_hash(self, asset):
-        document_hash = self.event.args.metaDataHash
-        return (
-            sha256(json.dumps(asset).encode("utf-8")).hexdigest() == document_hash.hex()
-        )
-
     def add_aqua_data(self, record):
         """Adds keys that are specific to Aquarius, on top of the DDO structure:
         event, nft, datatokens."""
@@ -96,10 +88,10 @@ class EventProcessor(ABC):
 
         record[AquariusCustomDDOFields.NFT] = {
             "address": self.dt_contract.address,
-            "name": self.dt_contract.caller.name(),
-            "symbol": self.dt_contract.caller.symbol(),
-            "state": self.dt_contract.caller.metaDataState(),
-            "owner": self.dt_contract.caller.ownerOf(1),
+            "name": self.get_token_name(self.dt_contract),
+            "symbol": self.get_token_symbol(self.dt_contract),
+            "state": self.get_nft_metaDataState(),
+            "owner": self.get_nft_owner(),
         }
 
         record[AquariusCustomDDOFields.DATATOKENS] = self.get_tokens_info(record)
@@ -139,13 +131,49 @@ class EventProcessor(ABC):
             datatokens.append(
                 {
                     "address": service["datatokenAddress"],
-                    "name": token_contract.caller.name(),
-                    "symbol": token_contract.caller.symbol(),
+                    "name": self.get_token_name(token_contract),
+                    "symbol": self.get_token_symbol(token_contract),
                     "serviceId": service["id"],
                 }
             )
 
         return datatokens
+
+    def get_token_name(self, contract):
+        data = ""
+        try:
+            data = contract.caller.name()
+        except Exception as e:
+            logger.warn(f"Cannot get token name: {e}")
+            pass
+        return data
+
+    def get_token_symbol(self, contract):
+        data = ""
+        try:
+            data = contract.caller.symbol()
+        except Exception as e:
+            logger.warn(f"Cannot get token symbol: {e}")
+            pass
+        return data
+
+    def get_nft_metaDataState(self):
+        data = ""
+        try:
+            data = self.dt_contract.caller.metaDataState()
+        except Exception as e:
+            logger.warn(f"Cannot get NFT metaDataState: {e}")
+            pass
+        return data
+
+    def get_nft_owner(self):
+        data = ""
+        try:
+            data = self.dt_contract.caller.ownerOf(1)
+        except Exception as e:
+            logger.warn(f"Cannot get NFT ownerOf: {e}")
+            pass
+        return data
 
 
 class MetadataCreatedProcessor(EventProcessor):
@@ -191,10 +219,10 @@ class MetadataCreatedProcessor(EventProcessor):
             self.event.address,
             self._chain_id,
             txid,
+            self.event.args.metaDataHash,
         )
-
-        if not self.check_document_hash(asset):
-            return False
+        if not asset:
+            raise Exception("Decrypt ddo failed")
 
         self.did = asset["id"]
         did, sender_address = self.did, self.sender_address
@@ -275,10 +303,11 @@ class MetadataUpdatedProcessor(EventProcessor):
             self.event.address,
             self._chain_id,
             txid,
+            self.event.args.metaDataHash,
         )
 
-        if not self.check_document_hash(asset):
-            return False
+        if not asset:
+            raise Exception("Decrypt ddo failed")
 
         self.did = asset["id"]
         did, sender_address = self.did, self.sender_address
@@ -344,12 +373,6 @@ class MetadataUpdatedProcessor(EventProcessor):
             logger.warning(
                 f"asset was updated later (block: {ddo_block}) vs transaction block: {self.block}"
             )
-            return False
-
-        if not compare_eth_addresses(
-            old_asset["publicKey"][0]["owner"], sender_address, logger
-        ):
-            logger.warning("Transaction sender must mach ddo owner")
             return False
 
         return True

--- a/tests/test_ddo_checker_shacl.py
+++ b/tests/test_ddo_checker_shacl.py
@@ -50,7 +50,7 @@ def test_sample_schema():
     assert not conforms
     errors = parse_report_to_errors(results_graph)
     assert "id" in errors
-    assert errors["id"] == "Less than 1 value on schema:id"
+    assert "Less than 1 value on schema" in errors["id"]
 
     data = json.dumps(
         {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -39,6 +39,7 @@ def run_test(client, base_ddo_url, events_instance, flags):
     assert published_ddo["id"] == did
     for service in published_ddo["services"]:
         assert service["datatokenAddress"] == erc20_address
+        assert service["name"] == "dataAssetAccess"
 
     _ddo["metadata"]["name"] = "Updated ddo by event"
     send_create_update_tx("update", _ddo, bytes([flags]), test_account1)

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -39,7 +39,7 @@ def run_test(client, base_ddo_url, events_instance, flags):
     assert published_ddo["id"] == did
     for service in published_ddo["services"]:
         assert service["datatokenAddress"] == erc20_address
-        assert service["name"] == "dataAssetAccess"
+        assert service["name"] in ["dataAssetAccess", "dataAssetComputingService"]
 
     _ddo["metadata"]["name"] = "Updated ddo by event"
     send_create_update_tx("update", _ddo, bytes([flags]), test_account1)

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -107,18 +107,6 @@ def test_is_publisher_allowed():
     assert processor.is_publisher_allowed(processor.sender_address) is True
 
 
-def test_check_document_hash():
-    original_dict = {"some_json": "for testing"}
-    original_string = json.dumps(original_dict)
-    hash_result = sha256(original_string.encode("utf-8")).hexdigest()
-    event_sample.args.__dict__["metaDataHash"] = Web3.toBytes(hexstr=hash_result)
-
-    processor = MetadataCreatedProcessor(
-        event_sample, None, None, None, None, None, None, None
-    )
-    assert processor.check_document_hash(original_dict) is True
-
-
 def test_process_fallback(monkeypatch, client, base_ddo_url, events_object):
     config_file = app.config["AQUARIUS_CONFIG_FILE"]
     web3 = setup_web3(config_file)

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -144,6 +144,3 @@ def test_do_decode_update():
         "publicKey": [{"owner": "some_address"}],
     }
     assert processor.check_update(None, old_asset, "") is False
-
-    processor.block = bk_block
-    assert processor.check_update(None, old_asset, "") is False

--- a/tests/test_validate_api.py
+++ b/tests/test_validate_api.py
@@ -79,7 +79,5 @@ def test_validate_error_remote(client, base_ddo_url, monkeypatch):
         data={"@context": ["test"], "services": "bla", "version": "4.0.0"},
     )
     assert rv.status_code == 200
-    assert (
-        rv.json["errors"]["services"]
-        == "Value does not conform to Shape schema:ServiceShape"
-    )
+    assert "Value does not conform to Shape schema" in rv.json["errors"]["services"]
+    assert "ServiceShape" in rv.json["errors"]["services"]


### PR DESCRIPTION
Fixes:
 - remove hash based on json, use provider response  (Reason:  JSON.dumps in python is different than json.stringify in nodejs  -> assets published using ocean.js were failing the hash check)
 - make sure we output an error when PRIVATE_KEY is not defined
 - moved all token name, symbol, etc getters to functions so we can log them and ignore failures
 - remove old public key check  (the owner is the nft, all logic is in the smartcontract, so he can update the ddo using any params, maybe he is changing owners)