### PR TITLE
remove cpu, gpu, etc from required

### DIFF
--- a/aquarius/ddo_checker/shacl_schemas/v4/remote_4.0.0.ttl
+++ b/aquarius/ddo_checker/shacl_schemas/v4/remote_4.0.0.ttl
@@ -244,41 +244,6 @@ schema:ServiceShape
 schema:ComputeShape
     sh:targetClass schema:Compute ;
     sh:property [
-        sh:path schema:namespace ;
-        sh:datatype xsd:string ;
-        sh:pattern "^(.*)$" ;
-        sh:minCount 1;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
-        sh:path schema:cpus ;
-        sh:datatype xsd:integer ;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
-        sh:path schema:gpus ;
-        sh:datatype xsd:integer ;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
-        sh:path schema:gpuType ;
-        sh:datatype xsd:string ;
-        sh:pattern "^(.*)$" ;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
-        sh:path schema:memory ;
-        sh:datatype xsd:string ;
-        sh:pattern "^(.*)$" ;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
-        sh:path schema:volumeSize;
-        sh:datatype xsd:string ;
-        sh:pattern "^(.*)$" ;
-        sh:maxCount 1;
-    ] ;
-    sh:property [
         sh:path schema:allowRawAlgorithm ;
         sh:datatype xsd:boolean ;
         sh:minCount 1;


### PR DESCRIPTION
Due to https://github.com/oceanprotocol/multi-repo-issue/issues/127, there is no need to store compute related fields in the ddo (like cpu, namespace, volume size, etc).

Once this is merged, I will remove them from V4 DDO docs as well