### PR TITLE
Add XML sitemap used by robot.txt in market

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Aquarius is a simple, lightweight scanner and API. It is built using Python, usi
 - `POST api/v1/aquarius/assets/ddo/encrypt` and `POST api/v1/aquarius/assets/ddo/encryptashex`: encrypts the asset using the `EVENTS_ECIES_PRIVATE_KEY` env var. Unencrypted assets can be read by any Aquarius instance, but if you are running a private Aquarius, this makes your assets private.
 - `GET api/v1/aquarius/chains/list`: lists all chains indexed by the Aquarius version
 - `GET api/v1/aquarius/chains/status/<chain_id>`: shows the status of the chain corresponding to the given `chain_id`
+- `GET api/v1/aquarius/assets/sitemap`: outputs an XML sitemap used by the [market](https://github.com/oceanprotocol/market)
 
 ### The EventsMonitor
 


### PR DESCRIPTION
Fulfilment of [mPowered’s DAO, Round 13](https://port.oceanprotocol.com/t/round-13-improving-search-engine-discoverability-for-the-current-ocean-data-marketplace/1308) relating to search engine optimisations (SEO).

Add a new endpoint `/api/v1/aquarius/assets/sitemap` which outputs an XML sitemap for use by the market. Takes in one GET parameter, `base`, which is the base URL for a market (e.g. `https://market.oceanprotocol.com`)

The ES query is just for all assets that are in all mainnet chains and are not in purgatory, sorted by creation date newest to oldest.