### PR TITLE
Fix extraData size error in mumbai network

### DIFF
--- a/aquarius/events/util.py
+++ b/aquarius/events/util.py
@@ -167,6 +167,7 @@ def setup_web3(config_file, _logger=None):
     if (
         get_bool_env_value("USE_POA_MIDDLEWARE", 0)
         or get_network_name().lower() == "rinkeby"
+        or get_network_name().lower() == "mumbai"
     ):
         from web3.middleware import geth_poa_middleware
 


### PR DESCRIPTION
Signed-off-by: Pablo Maldonado <pablo@oceanprotocol.com>

<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->

Fixes #708 .

- Add mumbai to the `geth_poa_middleware` config


