### PR TITLE
Eliminate MismatchedABI warnings

### DIFF
--- a/aquarius/events/events_monitor.py
+++ b/aquarius/events/events_monitor.py
@@ -6,13 +6,11 @@ import json
 import logging
 import os
 import time
-from json import JSONDecodeError
 from threading import Thread
 
 import elasticsearch
 from jsonsempai import magic  # noqa: F401
 
-from aquarius.app.auth_util import sanitize_addresses
 from aquarius.app.es_instance import ElasticsearchInstance
 from aquarius.app.util import get_bool_env_value, get_allowed_publishers
 from aquarius.block_utils import BlockProcessingClass
@@ -27,6 +25,8 @@ from aquarius.events.processors import (
 from aquarius.events.purgatory import Purgatory
 from aquarius.events.util import get_metadata_start_block
 from artifacts import ERC20Template, ERC721Template
+from web3.logs import DISCARD
+
 
 logger = logging.getLogger(__name__)
 
@@ -213,7 +213,7 @@ class EventsMonitor(BlockProcessingClass):
             )
             event_object = dt_contract.events[
                 EventTypes.get_value(event_name)
-            ]().processReceipt(receipt)[0]
+            ]().processReceipt(receipt, errors=DISCARD)[0]
             try:
                 event_processor = processor(
                     *([event_object, dt_contract, receipt["from"]] + processor_args)
@@ -256,10 +256,7 @@ class EventsMonitor(BlockProcessingClass):
         for event in events:
             try:
                 event_processor = TokenURIUpdatedProcessor(
-                    event,
-                    self._web3,
-                    self._es_instance,
-                    self._chain_id,
+                    event, self._web3, self._es_instance, self._chain_id
                 )
                 event_processor.process()
             except Exception as e:

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -22,6 +22,8 @@ from aquarius.events.decryptor import decrypt_ddo
 from aquarius.events.util import make_did, get_dt_factory
 from aquarius.graphql import get_number_orders
 from artifacts import ERC20Template, ERC721Template
+from web3.logs import DISCARD
+
 
 logger = logging.getLogger(__name__)
 
@@ -424,9 +426,9 @@ class TokenURIUpdatedProcessor:
         )
 
         receipt = self.web3.eth.getTransactionReceipt(self.event.transactionHash)
-        event_decoded = erc721_contract.events.TokenURIUpdate().processReceipt(receipt)[
-            0
-        ]
+        event_decoded = erc721_contract.events.TokenURIUpdate().processReceipt(
+            receipt, errors=DISCARD
+        )[0]
 
         if self.asset["event"]["tx"] == event_decoded.transactionHash.hex():
             logger.warning("old asset has the same txid, no need to update")
@@ -465,10 +467,10 @@ class MetadataStateProcessor(EventProcessor):
 
         create_events = self.dt_contract.events[
             EventTypes.EVENT_METADATA_CREATED
-        ]().processReceipt(receipt)
+        ]().processReceipt(receipt, errors=DISCARD)
         update_events = self.dt_contract.events[
             EventTypes.EVENT_METADATA_UPDATED
-        ]().processReceipt(receipt)
+        ]().processReceipt(receipt, errors=DISCARD)
 
         if not create_events and not update_events:
             logger.error("create/update ddo event not found")

--- a/aquarius/events/util.py
+++ b/aquarius/events/util.py
@@ -17,6 +17,8 @@ from addresses import address as contract_addresses
 from aquarius.app.util import get_bool_env_value
 from aquarius.events.http_provider import get_web3_connection_provider
 from artifacts import ERC721Factory
+from web3.logs import DISCARD
+
 
 logger = logging.getLogger(__name__)
 ENV_ADDRESS_FILE = "ADDRESS_FILE"
@@ -90,7 +92,7 @@ def deploy_datatoken(w3, account, name, symbol):
 
         return (
             dt_factory.events.NFTCreated()
-            .processReceipt(receipt)[0]
+            .processReceipt(receipt, errors=DISCARD)[0]
             .args.newTokenAddress
         )
     except Exception:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -19,6 +19,8 @@ from aquarius.events.http_provider import get_web3_connection_provider
 from aquarius.events.util import deploy_datatoken, make_did
 from artifacts import ERC721Template
 from tests.ddos.ddo_event_sample_v4 import ddo_event_sample_v4
+from web3.logs import DISCARD
+
 
 rpc = os.environ.get("EVENTS_RPC", "")
 provider = get_web3_connection_provider(rpc)
@@ -121,7 +123,9 @@ def send_create_update_tx(name, ddo, flags, account):
     ).transact()
     txn_receipt = get_web3().eth.wait_for_transaction_receipt(txn_hash)
 
-    _ = getattr(dt_contract.events, event_name)().processReceipt(txn_receipt)
+    _ = getattr(dt_contract.events, event_name)().processReceipt(
+        txn_receipt, errors=DISCARD
+    )
 
     return txn_receipt, dt_contract, erc20_address
 


### PR DESCRIPTION
Closes #721.

Changes:

- Eliminate MismatchedABI warnings by adding `errors=DISCARD` argument to all `processReceipt() calls.