### PR TITLE
Arweave Integration Milestone 1: Publish using transaction ID

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,7 +23,6 @@ jobs:
         with:
           repository: "oceanprotocol/barge"
           path: 'barge'
-          ref: v4
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Barge
         with:
-          repository: "oceanprotocol/barge"
+          repository: "MantisClone/barge"
           path: 'barge'
-          ref: v4
+          ref: arweave-integration
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,8 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Barge
         with:
-          repository: "oceanprotocol/barge"
+          repository: "MantisClone/barge"
           path: 'barge'
+          ref: arweave-integration
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -21,9 +21,9 @@ jobs:
       - uses: actions/checkout@v2
         name: Checkout Barge
         with:
-          repository: "MantisClone/barge"
+          repository: "oceanprotocol/barge"
           path: 'barge'
-          ref: arweave-integration
+          ref: v4
       - name: Run Barge
         working-directory: ${{ github.workspace }}/barge
         run: |


### PR DESCRIPTION
> **Warning**
> This PR is not meant to be merged. It shows that the Aquarius tests pass when using the provider changes.

Towards https://github.com/oceanprotocol/multi-repo-issue/issues/151.

Changes:

- Hack CI to use `MantisClone/barge` repo and `arweave-integration` branch instead of `oceanprotocol/barge`

# Why no changes to Aquarius?

Arweave integration adds a new file type.  but the `services[0].files` are encrypted by the time Aquarius sees it, and thus no changes are needed.
