### PR TITLE
Restore nft state during EVENT_METADATA_STATE processing

### DIFF
--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -196,6 +196,18 @@ class MetadataCreatedProcessor(EventProcessor):
 
         return _record
 
+    def restore_nft_state(self, ddo):
+        ddo["nft"]["state"] = MetadataStates.ACTIVE
+        record_str = json.dumps(ddo)
+        self._es_instance.update(record_str, self.did)
+        _record = json.loads(record_str)
+        name = _record["metadata"]["name"]
+        sender_address = _record["nft"]["owner"]
+        logger.info(
+            f"DDO saved: did={self.did}, name={name}, "
+            f"publisher={sender_address}, chainId={self._chain_id}, updated state={MetadataStates.ACTIVE}"
+        )
+
     def process(self):
         txid = self.txid
 
@@ -235,8 +247,14 @@ class MetadataCreatedProcessor(EventProcessor):
         try:
             ddo = self._es_instance.read(did)
             if ddo["chainId"] == self._chain_id:
-                logger.warning(f"{did} is already registered on this chainId")
-                return
+                ddoState = ddo["nft"]["state"]
+                logger.warning(f"MetadataCreatedProcessor try {did} , ddp {ddoState}")
+                if ddo["nft"]["state"] == MetadataStates.ACTIVE:
+                    logger.warning(f"{did} is already registered on this chainId")
+                    return
+                logger.warning(f"MetadataCreatedProcessor try {did} not return, restore nft state")
+                self.restore_nft_state(ddo)
+                return True
         except Exception:
             pass
 
@@ -485,6 +503,12 @@ class MetadataStateProcessor(EventProcessor):
             return False
 
         event = create_events[0] if create_events else update_events[0]
+        print(f"MetadataStateProcessor create_events[0]: {create_events}")
+        if create_events:
+            print(f"MetadataStateProcessor update_events[0]: {create_events[0]}")
+        print(f"MetadataStateProcessor update_events: {update_events}")
+        if update_events:
+            print(f"MetadataStateProcessor update_events[0]: {update_events[0]}")
 
         event_processor = MetadataCreatedProcessor(
             event,

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -429,6 +429,21 @@ def test_metadata_state_update(client, base_ddo_url, events_object):
         == MetadataStates.ORDERING_DISABLED
     )
 
+    # MetadataState updated to active should delegate to MetadataCreated processor
+    # and reactivate the existing asset
+    send_set_metadata_state_tx(
+        ddo=_ddo, account=test_account1, state=MetadataStates.ACTIVE
+    )
+    events_object.process_current_blocks()
+    time.sleep(30)
+    published_ddo = get_ddo(client, base_ddo_url, did)
+    # Existing asset has been reactivated
+    assert published_ddo["id"] == did
+    # The event after reactivated is kept as it uses the same original creation event
+    assert published_ddo["event"]["tx"] == initial_ddo["event"]["tx"]
+    # The NFT state is active
+    assert published_ddo[AquariusCustomDDOFields.NFT]["state"] == MetadataStates.ACTIVE
+
 
 def test_token_uri_update(client, base_ddo_url, events_object):
     web3 = events_object._web3  # get_web3()


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

When processing EVENT_METADATA_STATE, if previous nft state are not active, allow to change to the new nft state.

## Is this PR related with an open issue?

Related to Issue #836 

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation

#### Funny gif

![Put a link of a funny gif inside the parenthesis-->](https://spectrum-sitecore-spectrumbrands.netdna-ssl.com/~/media/Pet/Tetra/Images/Learning%20Centers/Fish%20Learning%20Center/JellyfishAni.gif)