### PR TITLE
export event version

### DIFF
--- a/API.md
+++ b/API.md
@@ -282,7 +282,8 @@
         - Description: Successful request
         - Body
             ```JSON
-            {"last_block": 25198729}
+            {"last_block": 25198729,
+            "version": "4.4.1"}
             ```
 
 ## Others

--- a/aquarius/config.py
+++ b/aquarius/config.py
@@ -27,6 +27,12 @@ config_defaults = {
 }
 
 
+def get_version():
+    conf = configparser.ConfigParser()
+    conf.read(".bumpversion.cfg")
+    return conf["bumpversion"]["current_version"]
+
+
 class Config(configparser.ConfigParser):
     def __init__(self, filename=None, **kwargs):
         """

--- a/aquarius/events/events_monitor.py
+++ b/aquarius/events/events_monitor.py
@@ -14,6 +14,7 @@ from jsonsempai import magic  # noqa: F401
 from aquarius.app.es_instance import ElasticsearchInstance
 from aquarius.app.util import get_bool_env_value, get_allowed_publishers
 from aquarius.block_utils import BlockProcessingClass
+from aquarius.config import get_version
 from aquarius.retry_mechanism import RetryMechanism
 from aquarius.events.constants import EventTypes
 from aquarius.events.processors import (
@@ -377,7 +378,7 @@ class EventsMonitor(BlockProcessingClass):
         stored_block = self.get_last_processed_block()
         if block <= stored_block:
             return
-        record = {"last_block": block}
+        record = {"last_block": block, "version": get_version()}
         try:
             self._es_instance.es.index(
                 index=self._other_db_index,

--- a/aquarius/run.py
+++ b/aquarius/run.py
@@ -18,7 +18,7 @@ from aquarius.app.assets import assets
 from aquarius.app.chains import chains
 from aquarius.app.es_instance import ElasticsearchInstance
 from aquarius.app.util import get_bool_env_value
-from aquarius.config import Config
+from aquarius.config import Config, get_version
 from aquarius.constants import BaseURLs, Metadata
 from aquarius.events.events_monitor import EventsMonitor
 from aquarius.events.util import setup_web3
@@ -34,12 +34,6 @@ es_instance = ElasticsearchInstance(app.config["AQUARIUS_CONFIG_FILE"])
 def set_rbac_headers():
     if os.getenv("RBAC_SERVER_URL"):
         RBAC.set_headers(request)
-
-
-def get_version():
-    conf = configparser.ConfigParser()
-    conf.read(".bumpversion.cfg")
-    return conf["bumpversion"]["current_version"]
 
 
 @app.route("/")

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -2,27 +2,28 @@
 # Copyright 2021 Ocean Protocol Foundation
 # SPDX-License-Identifier: Apache-2.0
 #
-from datetime import timedelta
+import json
 import logging
 import os
-import pytest
 import threading
+import time
+from datetime import timedelta
+from unittest.mock import patch
 
 import elasticsearch
-import json
-import time
-from jsonsempai import magic  # noqa: F401
+import pytest
+from artifacts import ERC20Template, ERC721Template, FixedRateExchange
 from eth_keys import KeyAPI
 from eth_keys.backends import NativeECCBackend
-from unittest.mock import patch
+from jsonsempai import magic  # noqa: F401
 from web3.main import Web3
 
+from aquarius.app.util import get_aquarius_wallet
+from aquarius.config import get_version
 from aquarius.events.constants import AquariusCustomDDOFields, MetadataStates
 from aquarius.events.events_monitor import EventsMonitor
-from aquarius.events.util import setup_web3, get_address_file, get_fre
-from aquarius.app.util import get_aquarius_wallet
+from aquarius.events.util import get_address_file, get_fre, setup_web3
 from aquarius.myapp import app
-from artifacts import ERC20Template, ERC721Template, FixedRateExchange
 from tests.helpers import (
     get_ddo,
     get_web3,
@@ -125,6 +126,7 @@ def test_get_chain_status(client, chains_url):
     )
     chain_status = json.loads(rv.data.decode("utf-8"))
     assert int(chain_status["last_block"]) > 0
+    assert chain_status["version"] == get_version()
 
 
 def test_get_assets_in_chain(client, events_object):


### PR DESCRIPTION
<!--
Copyright 2021 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

When running Aquarius with multiple event monitors, it's hard to detect what version is used.


## Types of changes
Export events monitor version in ["/api/aquarius/chains/status/{chain_id}"](https://github.com/oceanprotocol/aquarius/blob/main/API.md#get-apiaquariuschainsstatuschain_id)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 

This PR is toward functionality, because performance wise, it's not the best idea to always update es and keep the same value (version)