### PR TITLE
Feature/new transfer ownership

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,8 +32,6 @@ jobs:
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" ] && break
             done
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
-        env:
-          SUBGRAPH_VERSION: nft
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -32,6 +32,8 @@ jobs:
             [ -f "$HOME/.ocean/ocean-contracts/artifacts/ready" ] && break
             done
           ls -la "$HOME/.ocean/ocean-contracts/artifacts/"
+        env:
+          SUBGRAPH_VERSION: nft
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/aquarius/events/constants.py
+++ b/aquarius/events/constants.py
@@ -40,7 +40,6 @@ class EventTypes(SimpleEnum):
     EVENT_EXCHANGE_CREATED = "ExchangeCreated"
     EVENT_EXCHANGE_RATE_CHANGED = "ExchangeRateChanged"
     EVENT_DISPENSER_CREATED = "DispenserCreated"
-    # EVENT_TRANSFER = "Transfer"
     hashes = {
         "0x5463569dcc320958360074a9ab27e809e8a6942c394fb151d139b5f7b4ecb1bd": {
             "type": EVENT_METADATA_CREATED,
@@ -74,10 +73,6 @@ class EventTypes(SimpleEnum):
             "type": EVENT_DISPENSER_CREATED,
             "text": "DispenserCreated(address,address,uint256,uint256,address)",
         },
-        # "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef": {
-        #    "type": EVENT_TRANSFER,
-        #    "text": "Transfer(address,address,uint256)",
-        # },
     }
 
 

--- a/aquarius/events/constants.py
+++ b/aquarius/events/constants.py
@@ -40,7 +40,7 @@ class EventTypes(SimpleEnum):
     EVENT_EXCHANGE_CREATED = "ExchangeCreated"
     EVENT_EXCHANGE_RATE_CHANGED = "ExchangeRateChanged"
     EVENT_DISPENSER_CREATED = "DispenserCreated"
-    EVENT_TRANSFER = "Transfer"
+    # EVENT_TRANSFER = "Transfer"
     hashes = {
         "0x5463569dcc320958360074a9ab27e809e8a6942c394fb151d139b5f7b4ecb1bd": {
             "type": EVENT_METADATA_CREATED,
@@ -74,10 +74,10 @@ class EventTypes(SimpleEnum):
             "type": EVENT_DISPENSER_CREATED,
             "text": "DispenserCreated(address,address,uint256,uint256,address)",
         },
-        "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef": {
-            "type": EVENT_TRANSFER,
-            "text": "Transfer(address,address,uint256)",
-        },
+        # "0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef": {
+        #    "type": EVENT_TRANSFER,
+        #    "text": "Transfer(address,address,uint256)",
+        # },
     }
 
 

--- a/aquarius/events/events_monitor.py
+++ b/aquarius/events/events_monitor.py
@@ -154,7 +154,7 @@ class EventsMonitor(BlockProcessingClass):
         self._thread_process_blocks_is_on = True
         t.start()
 
-        t = Thread(target=self.thread_process_blocks, daemon=True)
+        t = Thread(target=self.thread_process_nft_ownership, daemon=True)
         self._thread_process_nfts_is_on = False
         t.start()
 

--- a/aquarius/events/events_monitor.py
+++ b/aquarius/events/events_monitor.py
@@ -155,7 +155,7 @@ class EventsMonitor(BlockProcessingClass):
         t.start()
 
         t = Thread(target=self.thread_process_nft_ownership, daemon=True)
-        self._thread_process_nfts_is_on = False
+        self._thread_process_nfts_is_on = True
         t.start()
 
         if strtobool(os.getenv("PROCESS_RETRY_QUEUE", "0")):

--- a/aquarius/events/nft_ownership.py
+++ b/aquarius/events/nft_ownership.py
@@ -1,0 +1,119 @@
+#
+# Copyright 2021 Ocean Protocol Foundation
+# SPDX-License-Identifier: Apache-2.0
+#
+import json
+import logging
+import os
+import time
+from datetime import datetime
+
+import elasticsearch
+import requests
+from web3 import Web3
+
+
+from aquarius.events.util import get_defined_block, make_did
+from aquarius.graphql import get_nft_transfers
+from elasticsearch.exceptions import NotFoundError
+
+logger = logging.getLogger(__name__)
+
+
+class NftOwnership:
+    def __init__(self, es_instance, db_index, chain_id, events_monitor):
+        self.update_time = None
+        self._es_instance = es_instance
+        self._db_index = db_index
+        self._chain_id = chain_id
+        self._index_name = "nft_events_" + str(self._chain_id)
+        self._events_monitor = events_monitor
+
+    def get_last_processed_block(self):
+        """Get last processed_block, fallback to contract deployment block"""
+        block = get_defined_block(self._chain_id)
+        try:
+            # Re-establishing the connection with ES
+            while True:
+                try:
+                    if self._es_instance.es.ping() is True:
+                        break
+                except elasticsearch.exceptions.ElasticsearchException as es_err:
+                    logging.error(f"Elasticsearch error: {es_err}")
+                logging.error("Connection to ES failed. Trying to connect to back...")
+                time.sleep(5)
+            # logging.info("Stable connection to ES.")
+            last_block_record = self._es_instance.es.get(
+                index=self._db_index, id=self._index_name, doc_type="_doc"
+            )["_source"]
+            block = (
+                last_block_record["last_block"]
+                if last_block_record["last_block"] >= 0
+                else get_defined_block(self._chain_id)
+            )
+        except Exception as e:
+            # Retrieve the defined block.
+            if type(e) == elasticsearch.NotFoundError:
+                block = get_defined_block(self._chain_id)
+                logger.info(f"Retrieved the default block. NotFound error occurred.")
+            else:
+                logging.error(f"Cannot get last_block error={e}")
+        return block
+
+    def store_last_processed_block(self, block):
+        """Stores last processed block
+
+        Args:
+            block: last block that was processed
+        """
+        # make sure that we don't write a block < then needed
+        stored_block = self.get_last_processed_block()
+        logger.info(f"Storing last_processed_block {block}  (In Es: {stored_block})")
+        if block <= stored_block:
+            return
+        record = {"last_block": block}
+        try:
+            self._es_instance.es.index(
+                index=self._db_index,
+                id=self._index_name,
+                body=record,
+                doc_type="_doc",
+                refresh="wait_for",
+            )["_id"]
+
+        except elasticsearch.exceptions.RequestError:
+            logger.error(
+                f"store_last_processed_block: block={block} type={type(block)}, ES RequestError"
+            )
+
+    def update_lists(self):
+        """
+        Grab and process all nft transfership events from subgraph, starting from last known block
+        """
+        start_block = self.get_last_processed_block()
+        # never go past last indexed block, because we will not have the ddos
+        end_block = self._events_monitor.get_last_processed_block()
+        if end_block > start_block:
+            nft_transfers_list = get_nft_transfers(
+                start_block, end_block, self._chain_id
+            )
+            for transfer in nft_transfers_list:
+                did = make_did(
+                    Web3.toChecksumAddress(transfer["nft"]["id"]), self._chain_id
+                )
+                try:
+                    asset = self._es_instance.read(did)
+                    asset["nft"]["owner"] = Web3.toChecksumAddress(
+                        transfer["newOwner"]["id"]
+                    )
+                    self._es_instance.update(asset, did)
+                    logger.debug(f"Updated {did}: new owner: {asset['nft']['owner']}")
+                except NotFoundError:
+                    logger.debug(
+                        f"Unable to update new owner {transfer['newOwner']['id']} for did {did}:  Not Found"
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"Unable to update new owner {transfer['newOwner']['id']} for did {did}:  {e}"
+                    )
+                self.store_last_processed_block(transfer["block"])

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -539,34 +539,3 @@ class MetadataStateProcessor(EventProcessor):
                 return
 
         self.update_aqua_nft_state_data(self.event.args.state, self.did)
-
-
-class TransferProcessor:
-    def __init__(self, event, web3, es_instance, chain_id):
-        self.did = make_did(event.address, chain_id)
-        self.es_instance = es_instance
-        self.event = event
-        self.web3 = web3
-
-        try:
-            self.asset = self.es_instance.exists(self.did)
-        except Exception:
-            self.asset = None
-
-    def process(self):
-        if not self.asset:
-            return
-        self.asset = self.es_instance.read(self.did)
-
-        erc721_contract = self.web3.eth.contract(
-            abi=ERC721Template.abi,
-            address=self.web3.toChecksumAddress(self.event.address),
-        )
-        receipt = self.web3.eth.getTransactionReceipt(self.event.transactionHash)
-        event_decoded = erc721_contract.events.Transfer().processReceipt(
-            receipt, errors=DISCARD
-        )[0]
-        self.asset["nft"]["owner"] = event_decoded.args.to
-        logger.debug(f"Update owner for {self.did} to {event_decoded.args.to}")
-        self.es_instance.update(self.asset, self.did)
-        return self.asset

--- a/aquarius/graphql.py
+++ b/aquarius/graphql.py
@@ -146,4 +146,4 @@ def get_client(chain_id, block=None):
         last_block = get_last_block(client)
         time.sleep(2)
 
-    return
+    return client

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -462,10 +462,15 @@ def test_token_transfer(client, base_ddo_url, events_object):
     ).transact()
     _ = web3.eth.wait_for_transaction_receipt(txn_hash)
 
+    # allow events to reach our nft transfer block
     events_object.process_current_blocks()
+    # process nft transfers
+    events_object.nft_ownership.update_lists()
     updated_ddo = get_ddo(client, base_ddo_url, did)
     assert updated_ddo["id"] == did
-    assert updated_ddo["nft"]["owner"] == test_account2.address
+    assert web3.toChecksumAddress(
+        updated_ddo["nft"]["owner"]
+    ) == web3.toChecksumAddress(test_account2.address)
 
 
 def test_trigger_caching(client, base_ddo_url, events_object):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -173,8 +173,8 @@ def test_start_stop_events_monitor():
     monitor = EventsMonitor(setup_web3(config_file), config_file)
     with patch("aquarius.events.events_monitor.Thread.start") as mock:
         monitor.start_events_monitor()
-        mock.assert_called_once()
-
+        # we have 2 thread running
+        assert mock.call_count == 2
     monitor.stop_monitor()
 
 


### PR DESCRIPTION
Closes #937 

Changes:
 - removes nft_transfer event from main event loop
 - start a new thread that periodically fetches list of nft transfers from subgraph and updates ddos. It uses it's own index to keep last processed block