### PR TITLE
fix EOL state

### DIFF
--- a/aquarius/events/constants.py
+++ b/aquarius/events/constants.py
@@ -84,6 +84,12 @@ class MetadataStates(IntEnum):
     ORDERING_DISABLED = 4
 
 
+SoftDeleteMetadataStates = [
+    MetadataStates.DEPRECATED,
+    MetadataStates.REVOKED,
+]
+
+
 class AquariusCustomDDOFields(SimpleEnum):
     EVENT = "event"
     NFT = "nft"

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -640,7 +640,10 @@ class MetadataStateProcessor(EventProcessor):
                 f"Detected MetadataState changed for {self.did}, but it does not exists."
             )
             return
-        if self.event.args.state == MetadataStates.ACTIVE or self.event.args.state == MetadataStates.END_OF_LIFE:
+        if (
+            self.event.args.state == MetadataStates.ACTIVE
+            or self.event.args.state == MetadataStates.END_OF_LIFE
+        ):
             return self.restore_ddo()
 
         target_state = self.event.args.state

--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -640,12 +640,11 @@ class MetadataStateProcessor(EventProcessor):
                 f"Detected MetadataState changed for {self.did}, but it does not exists."
             )
             return
-        if self.event.args.state == MetadataStates.ACTIVE:
+        if self.event.args.state == MetadataStates.ACTIVE or self.event.args.state == MetadataStates.END_OF_LIFE:
             return self.restore_ddo()
 
         target_state = self.event.args.state
         if target_state in [
-            MetadataStates.END_OF_LIFE,
             MetadataStates.DEPRECATED,
             MetadataStates.REVOKED,
         ]:


### PR DESCRIPTION
When an asset is marked as EOL, it should be discoverable in OM, while ordering remains disabled