### PR TITLE
Add txId in payload for RBAC check for asset indexing

### DIFF
--- a/aquarius/events/processors.py
+++ b/aquarius/events/processors.py
@@ -59,8 +59,8 @@ class EventProcessor(ABC):
         self._chain_id = chain_id
         self.metadata_proofs = None
 
-    def check_permission(self, publisher_address):
-        if not os.getenv("RBAC_SERVER_URL") or not publisher_address:
+    def check_permission(self, publisher_address, tx_id):
+        if not os.getenv("RBAC_SERVER_URL") or not publisher_address or not tx_id:
             return True
 
         event_type = (
@@ -69,7 +69,7 @@ class EventProcessor(ABC):
             else "update"
         )
 
-        return RBAC.check_permission_rbac(event_type, publisher_address)
+        return RBAC.check_permission_rbac(event_type, publisher_address, tx_id)
 
     def add_aqua_data(self, record):
         """Adds keys that are specific to Aquarius, on top of the DDO structure:
@@ -300,7 +300,7 @@ class MetadataCreatedProcessor(EventProcessor):
         except Exception:
             pass
 
-        permission = self.check_permission(sender_address)
+        permission = self.check_permission(sender_address, txid)
         if not permission:
             error = "RBAC permission denied."
             logger.info(error)
@@ -446,7 +446,7 @@ class MetadataUpdatedProcessor(EventProcessor):
         self.did = asset["id"]
         did, sender_address = self.did, self.sender_address
 
-        permission = self.check_permission(sender_address)
+        permission = self.check_permission(sender_address, txid)
         if not permission:
             error = "RBAC permission denied."
             logger.info(error)

--- a/aquarius/rbac.py
+++ b/aquarius/rbac.py
@@ -71,11 +71,14 @@ class RBAC:
         ).json()
 
     @staticmethod
-    def check_permission_rbac(event_type, address):
+    def check_permission_rbac(event_type, address, tx_id):
         payload = {
             "eventType": event_type,
             "component": "metadatacache",
-            "credentials": {"type": "address", "value": address},
+            "credentials": [
+                {"type": "address", "value": address},
+                {"type": "address", "value": tx_id},
+            ],
         }
 
         try:

--- a/tests/test_processors.py
+++ b/tests/test_processors.py
@@ -81,7 +81,7 @@ def test_check_permission(monkeypatch):
     )
     with patch("requests.post") as mock:
         mock.side_effect = Exception("Boom!")
-        assert processor.check_permission("some_address") is False
+        assert processor.check_permission("some_address", "some tx id") is False
 
     # will affect the process() function too
     with pytest.raises(Exception):


### PR DESCRIPTION
<!--
Copyright 2023 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

Add txId in payload for RBAC check for asset indexing

## Is this PR related with an open issue?

Related to Issue #1065 

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [X] Follows the code style of this project.
- [X] Tests Cover Changes
- [X] Documentation
