### PR TITLE
Change chain_id to chainId

### DIFF
--- a/aquarius/app/assets.py
+++ b/aquarius/app/assets.py
@@ -419,7 +419,7 @@ def trigger_caching():
     try:
         data = request.args if request.args else request.json
         tx_id = data.get("transactionId")
-        chain_id = data.get("chain_id")
+        chain_id = data.get("chainId")
         if not tx_id or not chain_id:
             return (
                 jsonify(error="Invalid transactionId or chain_id"),


### PR DESCRIPTION
<!--
Copyright 2023 Ocean Protocol Foundation
SPDX-License-Identifier: Apache-2.0
-->
## Description

Fixes the bug in the `trigger_caching` function where the incorrect key (`chain_id`) was used instead of the correct key (`chainId`) to extract the `chainId` value from the request payload.

## Is this PR related with an open issue?

Related to Issue Related to Issue [1097](https://github.com/oceanprotocol/aquarius/issues/1097). The issue is located in the `aquarius/app/assets.py` file.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [ ] Tests Cover Changes
- [ ] Documentation